### PR TITLE
Make roadmap link relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All setup and usage instructions are located on [docs.mau.fi]. Some quick links:
 * Basic usage: [Authentication](https://docs.mau.fi/bridges/go/gmessages/authentication.html)
 
 ### Features & Roadmap
-[ROADMAP.md](https://github.com/mautrix/gmessages/blob/master/ROADMAP.md)
+[ROADMAP.md](ROADMAP.md)
 contains a general overview of what is supported by the bridge.
 
 ## Discussion


### PR DESCRIPTION
The roadmap link previously linked to ROADMAP.md in the master branch. That branch does not exist anymore, and using absolute links creates a dependency on one branch.