### PR TITLE
Add user options to disable battery and certain connected messages

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -52,6 +52,8 @@ func (br *GMBridge) RegisterCommands() {
 		cmdDisconnect,
 		cmdSetActive,
 		cmdPing,
+		cmdToggleBatteryNotifications,
+		cmdToggleVerboseNotifications,
 		cmdPM,
 		cmdDeletePortal,
 		cmdDeleteAllPortals,
@@ -400,6 +402,44 @@ func fnPing(ce *WrappedCommandEvent) {
 		}
 		ce.Reply("Linked to %s and active as primary browser%s", ce.User.PhoneID, modifierStr)
 	}
+}
+
+var cmdToggleBatteryNotifications = &commands.FullHandler{
+	Func:    wrapCommand(fnToggleBatteryNotifications),
+	Name:    "toggle-battery-notifications",
+	Help: commands.HelpMeta{
+		Section:     HelpSectionConnectionManagement,
+		Description: "Silence Battery statuses.",
+	},
+}
+
+func fnToggleBatteryNotifications(ce *WrappedCommandEvent) {
+	ce.User.toggleNotifyBattery()
+	if ce.User.DisableNotifyBattery {
+		ce.Reply("Disabled battery notifications")
+	} else {
+		ce.Reply("Enabled battery notifications")
+	}
+	ce.ZLog.Trace().Msg("ToggleBatteryNotifications command finished")
+}
+
+var cmdToggleVerboseNotifications = &commands.FullHandler{
+	Func:    wrapCommand(fnToggleVerboseNotifications),
+	Name:    "toggle-verbose-notifications",
+	Help: commands.HelpMeta{
+		Section:     HelpSectionConnectionManagement,
+		Description: "Silence Connected statuses when session changes and no data received recently.",
+	},
+}
+
+func fnToggleVerboseNotifications(ce *WrappedCommandEvent) {
+	ce.User.toggleNotifyVerbose()
+	if ce.User.DisableNotifyVerbose {
+		ce.Reply("Disabled verbose notifications")
+	} else {
+		ce.Reply("Enabled verbose notifications")
+	}
+	ce.ZLog.Trace().Msg("ToggleVerboseNotifications command finished")
 }
 
 var cmdPM = &commands.FullHandler{

--- a/database/upgrades/11-user-settings.sql
+++ b/database/upgrades/11-user-settings.sql
@@ -1,0 +1,3 @@
+-- v11 (compatible with v10+): User settings 
+ALTER TABLE "user" ADD COLUMN disable_notify_battery BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "user" ADD COLUMN disable_notify_verbose BOOLEAN NOT NULL DEFAULT false;

--- a/libgm/events/ready.go
+++ b/libgm/events/ready.go
@@ -19,6 +19,8 @@ type GaiaLoggedOut struct{}
 
 type NoDataReceived struct{}
 
+type RecentlyDisconnected struct{}
+
 type AccountChange struct {
 	*gmproto.AccountChangeOrSomethingEvent
 	IsFake bool


### PR DESCRIPTION
This is an attempt of supporting issue #17.

I wanted to make the changes not break existing configurations. and the options to be toggled per user, so I added to "Connection Management" section of commands the following commands:

1. toggle-battery-notifications - Silence Battery statuses.
2. toggle-verbose-notifications - Silence Connected statuses when session changes and no data received recently.

The battery one toggles both "Phone battery restored" and "Your phone's battery is low" for the user.

The goal of toggle-verbose-notifications is to silence updates when everything is working as expected. If the status "Connected to Google Messages" is due to a disconnection longer for 5 minutes for example it will still show, but it will hide it when a session changes or when there is simply no activity.