### PR TITLE
handlegmessages: ignore spurious MESSAGE_DELETED events with zero timestamp

### DIFF
--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -613,6 +613,12 @@ var (
 func (m *MessageEvent) GetType() bridgev2.RemoteEventType {
 	switch m.GetMessageStatus().GetStatus() {
 	case gmproto.MessageStatusType_MESSAGE_DELETED:
+		// Ignore deletion events with zero timestamp, as those are spurious
+		// events pushed during mobile database syncs that don't represent
+		// actual user-initiated deletions.
+		if m.Timestamp == 0 {
+			return bridgev2.RemoteEventUnknown
+		}
 		return bridgev2.RemoteEventMessageRemove
 	default:
 		return bridgev2.RemoteEventMessageUpsert


### PR DESCRIPTION
Fixes [PLAT-36070](https://linear.app/beeper/issue/PLAT-36070/aaronbieber-google-messages-rcs-message-history-appears-deleted-in)

During mobile database syncs, the phone pushes `MESSAGE_DELETED` events with zero timestamps and empty participant IDs for messages that are not actually deleted. These cause irreversible redactions in Matrix.

This adds a guard in `GetType()` to only process `MESSAGE_DELETED` when the event has a non-zero timestamp. When the timestamp is zero, the event is returned as `RemoteEventUnknown` which the framework silently drops.

**Evidence from production logs (`@aaronbieber:beeper.com`, 2026-04-15):**

```
09:57:58Z portal=1.10   msg=1.24751 status=MESSAGE_DELETED ts=0 participant_id=""
09:57:59Z portal=1.769  msg=1.24739 status=MESSAGE_DELETED ts=0 participant_id=""
09:57:59Z portal=1.1693 msg=1.24748 status=MESSAGE_DELETED ts=0 participant_id=""
09:57:59Z portal=1.10   msg=1.24749 status=MESSAGE_DELETED ts=0 participant_id=""
09:57:59Z portal=1.1696 msg=1.24743 status=MESSAGE_DELETED ts=0 participant_id=""
```

These arrived in a burst across 4 unrelated portals in ~1 second, immediately before a `MOBILE_DATABASE_SYNC_STARTED` / `MOBILE_DATABASE_SYNC_COMPLETE` cycle. Messages were confirmed present on the user's phone.