### PR TITLE
handlegmessages: verify message deletion before redacting

### DIFF
--- a/pkg/connector/chatsync.go
+++ b/pkg/connector/chatsync.go
@@ -31,8 +31,8 @@ import (
 )
 
 func (gc *GMClient) SyncConversations(ctx context.Context, lastDataReceived time.Time, minimalSync bool) {
-	gc.syncCount.Add(1)
-	defer gc.syncCount.Add(-1)
+	gc.syncingConversations.Store(true)
+	defer gc.syncingConversations.Store(false)
 	log := zerolog.Ctx(ctx)
 	log.Info().Msg("Fetching conversation list")
 	resp, err := gc.Client.ListConversations(gc.Main.Config.InitialChatSyncCount, gmproto.ListConversationsRequest_INBOX)

--- a/pkg/connector/chatsync.go
+++ b/pkg/connector/chatsync.go
@@ -31,6 +31,8 @@ import (
 )
 
 func (gc *GMClient) SyncConversations(ctx context.Context, lastDataReceived time.Time, minimalSync bool) {
+	gc.syncCount.Add(1)
+	defer gc.syncCount.Add(-1)
 	log := zerolog.Ctx(ctx)
 	log.Info().Msg("Fetching conversation list")
 	resp, err := gc.Client.ListConversations(gc.Main.Config.InitialChatSyncCount, gmproto.ListConversationsRequest_INBOX)

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -64,6 +64,7 @@ type GMClient struct {
 	didHackySetActive           bool
 	noDataReceivedRecently      bool
 	lastDataReceived            time.Time
+	syncCount                   atomic.Int32
 
 	chatInfoCache        *exsync.Map[string, *gmproto.Conversation]
 	conversationMeta     map[string]*conversationMeta

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -64,7 +64,8 @@ type GMClient struct {
 	didHackySetActive           bool
 	noDataReceivedRecently      bool
 	lastDataReceived            time.Time
-	syncCount                   atomic.Int32
+	syncingConversations        atomic.Bool
+	syncingMobileDatabase       atomic.Bool
 
 	chatInfoCache        *exsync.Map[string, *gmproto.Conversation]
 	conversationMeta     map[string]*conversationMeta

--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -163,10 +163,13 @@ func (gc *GMClient) handleGMEvent(rawEvt any) {
 			Str("tmp_id", evt.GetTmpID()).
 			Bool("is_old", evt.IsOld).
 			Msg("Received message")
-		if evt.GetMessageStatus().GetStatus() == gmproto.MessageStatusType_MESSAGE_DELETED && gc.syncCount.Load() > 0 {
+		if evt.GetMessageStatus().GetStatus() == gmproto.MessageStatusType_MESSAGE_DELETED &&
+			(gc.syncingMobileDatabase.Load() || gc.syncingConversations.Load()) {
 			log.Debug().
 				Str("conversation_id", evt.GetConversationID()).
 				Str("message_id", evt.GetMessageID()).
+				Bool("syncing_mobile_database", gc.syncingMobileDatabase.Load()).
+				Bool("syncing_conversations", gc.syncingConversations.Load()).
 				Msg("Ignoring MESSAGE_DELETED during resync")
 		} else {
 			gc.Main.br.QueueRemoteEvent(gc.UserLogin, &MessageEvent{
@@ -293,9 +296,9 @@ func (gc *GMClient) handleUserAlert(ctx context.Context, v *gmproto.UserAlertEve
 		gc.lastDataReceived = time.Now()
 	case gmproto.AlertType_MOBILE_DATABASE_SYNC_STARTED:
 		log.Debug().Msg("Mobile database sync started")
-		gc.syncCount.Add(1)
+		gc.syncingMobileDatabase.Store(true)
 	case gmproto.AlertType_MOBILE_DATABASE_SYNC_COMPLETE:
-		gc.syncCount.Add(-1)
+		gc.syncingMobileDatabase.Store(false)
 		log.Debug().Msg("Making minimal sync due to mobile database sync complete event")
 		go gc.SyncConversations(ctx, gc.lastDataReceived, true)
 	case gmproto.AlertType_BROWSER_INACTIVE_FROM_TIMEOUT:

--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -163,10 +163,17 @@ func (gc *GMClient) handleGMEvent(rawEvt any) {
 			Str("tmp_id", evt.GetTmpID()).
 			Bool("is_old", evt.IsOld).
 			Msg("Received message")
-		gc.Main.br.QueueRemoteEvent(gc.UserLogin, &MessageEvent{
-			WrappedMessage: evt,
-			g:              gc,
-		})
+		if evt.GetMessageStatus().GetStatus() == gmproto.MessageStatusType_MESSAGE_DELETED && gc.syncCount.Load() > 0 {
+			log.Debug().
+				Str("conversation_id", evt.GetConversationID()).
+				Str("message_id", evt.GetMessageID()).
+				Msg("Ignoring MESSAGE_DELETED during resync")
+		} else {
+			gc.Main.br.QueueRemoteEvent(gc.UserLogin, &MessageEvent{
+				WrappedMessage: evt,
+				g:              gc,
+			})
+		}
 	case *gmproto.TypingData:
 		timeout := 15 * time.Second
 		if evt.Type == gmproto.TypingTypes_STOPPED_TYPING {
@@ -284,7 +291,11 @@ func (gc *GMClient) handleUserAlert(ctx context.Context, v *gmproto.UserAlertEve
 		}
 		gc.noDataReceivedRecently = false
 		gc.lastDataReceived = time.Now()
+	case gmproto.AlertType_MOBILE_DATABASE_SYNC_STARTED:
+		log.Debug().Msg("Mobile database sync started")
+		gc.syncCount.Add(1)
 	case gmproto.AlertType_MOBILE_DATABASE_SYNC_COMPLETE:
+		gc.syncCount.Add(-1)
 		log.Debug().Msg("Making minimal sync due to mobile database sync complete event")
 		go gc.SyncConversations(ctx, gc.lastDataReceived, true)
 	case gmproto.AlertType_BROWSER_INACTIVE_FROM_TIMEOUT:


### PR DESCRIPTION
## Verify message deletion on phone before redacting

### Problem

When the bridge reconnects or the phone syncs, `GET_UPDATES` delivers `MESSAGE_DELETED` (status 300) events for messages nobody actually deleted. The bridge blindly maps these to Matrix redactions, which are permanent. Once redacted, the messages are gone forever.

The `MESSAGE_DELETED` proto is a 14-byte skeleton — just a message ID, conversation ID, and status code. There are no extra fields to tell a real user-initiated delete from a spurious sync artifact. Both are byte-for-byte identical.

### What the official web client does

We reverse-engineered the Google Messages web client JS bundle and confirmed that it also processes **every** `MESSAGE_DELETED` event without filtering. It does not break because it only removes messages from its local IndexedDB cache — a soft delete that gets restored on the next sync. The phone is the source of truth, not the local cache.

Matrix does not have that luxury. Redactions are irreversible.

### How the fix works

Before redacting, we ask the phone: "do you actually still have this message?" via `FetchMessages`.

- If the message is **gone** from the phone → someone really deleted it (via `DELETE_MESSAGE` action 23, from the phone or web client) → proceed with redaction.
- If the message is **still there** → the `MESSAGE_DELETED` event was a sync artifact, nobody actually sent a delete command → skip the redaction.

The verification runs in a goroutine to avoid blocking the event handler (which shares the same connection used to receive the `FetchMessages` response).

This adds one `LIST_MESSAGES` round-trip (~150ms) per deletion event. Deletions are rare, so the cost is negligible.

Fixes [PLAT-36070](https://linear.app/beeper/issue/PLAT-36070/aaronbieber-google-messages-rcs-message-history-appears-deleted-in)