### PR TITLE
libgm: ignore is_old=true GaiaLoggedOut events from queue replay

### DIFF
--- a/pkg/libgm/event_handler.go
+++ b/pkg/libgm/event_handler.go
@@ -219,6 +219,13 @@ func (c *Client) handleUpdatesEvent(msg *IncomingRPCMessage) {
 	switch msg.Message.Action {
 	case gmproto.ActionType_GET_UPDATES:
 		if msg.DecryptedData == nil && bytes.Equal(msg.Message.UnencryptedData, hackyLoggedOutBytes) {
+			if msg.IsOld {
+				c.Logger.Debug().
+					Bool("is_old", msg.IsOld).
+					Int("skip_count", c.skipCount).
+					Msg("Ignoring stale GaiaLoggedOut from queue replay")
+				return
+			}
 			c.triggerEvent(&events.GaiaLoggedOut{})
 			return
 		}


### PR DESCRIPTION
libgm: ignore is_old=true GaiaLoggedOut events from queue replay

The hackyLoggedOutBytes short-circuit in handleUpdatesEvent fired GaiaLoggedOut unconditionally, even for replayed queue events marked is_old=true. After a failed pair attempt, Google's per-account message queue retains orphan events including logout tombstones. On the next successful pair, those stale events are replayed to the new session and the bridge would self-unpair within ~1 second of "Successfully logged in." This aligns the logout path with the other branches in the same switch that already respect msg.IsOld.

Fixes #52

### Checklist

* [ ] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
