### PR TITLE
[PLAT-35160] - fix: use comma-ok assertion in handleRemoteEcho to avoid panic from backfill path

### DIFF
--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -79,18 +79,17 @@ func (gc *GMClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Matri
 }
 
 func (gc *GMClient) handleRemoteEcho(rawEvt bridgev2.RemoteMessage, dbMessage *database.Message) (saveMessage bool, statusErr error) {
-	evt := rawEvt.(*MessageEvent)
-	_, textHash := getTextPart(evt.Message)
-	meta := &MessageMetadata{
-		IsOutgoing:      true,
-		Type:            evt.GetMessageStatus().GetStatus(),
-		TextHash:        textHash,
-		GlobalPartCount: len(evt.MessageInfo),
-	}
-	for _, part := range evt.GetMessageInfo() {
-		if part.GetMediaContent() != nil {
-			meta.MediaPartID = part.GetActionMessageID()
-			meta.MediaID = part.GetMediaContent().GetMediaID()
+	meta := &MessageMetadata{IsOutgoing: true}
+	if evt, ok := rawEvt.(*MessageEvent); ok {
+		_, textHash := getTextPart(evt.Message)
+		meta.Type = evt.GetMessageStatus().GetStatus()
+		meta.TextHash = textHash
+		meta.GlobalPartCount = len(evt.MessageInfo)
+		for _, part := range evt.GetMessageInfo() {
+			if part.GetMediaContent() != nil {
+				meta.MediaPartID = part.GetActionMessageID()
+				meta.MediaID = part.GetMediaContent().GetMediaID()
+			}
 		}
 	}
 	if gc.Main.br.Config.OutgoingMessageReID {


### PR DESCRIPTION
`handleRemoteEcho` uses a hard type assertion `rawEvt.(*MessageEvent)` which panics
when `checkPendingMessage` is called from the backfill dedup path in `cutoffMessages`,
where the event is a `*BackfillMessage` rather than a `*MessageEvent`.

The panic is recovered by the `defer/recover` in `handleSingleEvent`, but by that point
`checkPendingMessage` has already deleted the transaction ID from the `outgoingMessages`
map. The DB row is never inserted because that happens after the callback. This means
the subsequent `OUTGOING_COMPLETE` event finds no pending match and no existing DB row,
so it gets injected as a new double-puppeted event — producing a duplicate message in
the client.

The fix replaces the hard assertion with a comma-ok pattern. When the concrete type is
not `*MessageEvent` (i.e. the backfill path), the metadata is set to a minimal
`&MessageMetadata{IsOutgoing: true}`. The real status update will fill in the remaining
fields when `HandleExisting` processes the `OUTGOING_COMPLETE` event against the now-
existing DB row.