### PR TITLE
[PLAT-36100] - fix: sync conversations on phone reconnect to backfill missed messages

### DIFF
--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -100,6 +100,13 @@ func (gc *GMClient) handleGMEvent(rawEvt any) {
 			//go gc.sendMarkdownBridgeAlert(ctx, false, "Phone is responding again")
 			gc.phoneNotRespondingAlertSent = false
 		}
+		// Sync conversations after phone reconnection to backfill messages that
+		// arrived while the phone was unreachable. GET_UPDATES alone only returns
+		// the latest events per conversation, not a full history replay, so
+		// conversations with gaps will have missing messages without this.
+		if gc.ready {
+			go gc.SyncConversations(ctx, gc.lastDataReceived, false)
+		}
 	case *events.HackySetActiveMayFail:
 		go gc.hackyResetActive()
 	case *events.PingFailed:


### PR DESCRIPTION
## Problem

When a user's phone becomes unreachable (out of service, airplane mode, dead battery), the bridge detects this via ditto ping failures and enters `PhoneNotResponding` state. When the phone comes back online, the bridge receives `PhoneRespondingAgain` — but this handler **only set `PhoneResponding=true`** without triggering a conversation resync.

The existing `GET_UPDATES` call (sent when disconnected >1min) only returns the **latest events per conversation**, not a full history replay. So conversations with messages that arrived during the gap silently miss those messages — even though they're visible in Google Messages on the phone.

The `SyncConversations` path (which calls `ListConversations` → `CheckNeedsBackfill` → `FetchMessages`) was only triggered by `BROWSER_ACTIVE` user alert events, not phone reconnections.

## Fix

Add `SyncConversations` call to the `PhoneRespondingAgain` handler, mirroring what `BROWSER_ACTIVE` already does:

```go
case *events.PhoneRespondingAgain:
    gc.PhoneResponding = true
    gc.UserLogin.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
    // ...
    if gc.ready {
        go gc.SyncConversations(ctx, gc.lastDataReceived, false)
    }
```

`minimalSync=false` ensures all conversations are checked for gaps, not just ones with new data since `lastDataReceived`.

## Evidence

Production logs for an affected user (2026-04-18/19):

- **21:35 UTC** — Phone goes offline (last data received)
- **22:47 UTC** — Bridge detects via ditto ping failures, enters `BAD_CREDENTIALS`/`gm-phone-not-responding`
- **00:00:04 UTC** — Phone comes back (ping 116 succeeds after 2h13m), extra `GET_UPDATES` sent
- **00:08:30 UTC** — Only **2 messages** received for affected conversation via `GET_UPDATES` (out of many more visible in Google Messages)
- **Zero** `SyncConversations`, `BROWSER_ACTIVE`, or `Chat needs backfill` log entries after reconnection
- All other conversations that received `*gmproto.Conversation` updates were synced — but the affected conversation was not included in the `GET_UPDATES` response

## Edge Cases

1. **`gc.ready` guard**: Prevents calling `SyncConversations` before initial setup completes
2. **Brief flaps**: If the phone briefly disconnects and reconnects, `SyncConversations` with a recent `lastDataReceived` will see no gaps and return early via the `minimalSync` check
3. **Concurrent syncs**: Called in a goroutine; backfill queue is already serialized per-portal