### PR TITLE
libgm: refactor phone liveness and pings

### DIFF
--- a/pkg/libgm/client.go
+++ b/pkg/libgm/client.go
@@ -124,6 +124,7 @@ type Client struct {
 	pingInterval             time.Duration
 	alertTimeoutCount        int
 	pingShortCircuit         chan struct{}
+	phone                    phoneLiveness
 	dataReceiveCheckInterval time.Duration
 	nextDataReceiveCheck     time.Time
 	nextDataReceiveCheckLock sync.Mutex

--- a/pkg/libgm/event_handler.go
+++ b/pkg/libgm/event_handler.go
@@ -204,6 +204,9 @@ func (c *Client) HandleRPCMsg(rawMsg *gmproto.IncomingRPCMessage) {
 			c.skipCount--
 			msg.IsOld = true
 		}
+		if !msg.IsOld {
+			c.onPhoneActivity("data event")
+		}
 		c.handleUpdatesEvent(msg)
 	}
 }

--- a/pkg/libgm/longpoll.go
+++ b/pkg/libgm/longpoll.go
@@ -27,9 +27,106 @@ import (
 const defaultPingTimeout = 1 * time.Minute
 const shortPingTimeout = 10 * time.Second
 const minPingInterval = 30 * time.Second
+const initialRecoveryInterval = 1 * time.Minute
 const maxRepingTickerTime = 64 * time.Minute
 
+// If pings don't work we likely need to reconnect the session (assuming phone is alive)
+const setActiveSessionAfterTimeouts = 2
+const reconnectAfterTimeouts = 3
+
+// longPollGapCatchUp is how long the long polling connection has to have been down before
+// reopening it counts as a gap where events may have been missed.
+const longPollGapCatchUp = 1 * time.Minute
+
 var pingIDCounter atomic.Uint64
+
+// phoneLiveness tracks whether the phone (for this bridge client) is responding
+type phoneLiveness struct {
+	lock sync.Mutex
+
+	firstPingDone         bool
+	lastPingTime          time.Time
+	timeouts              int
+	sendFails             int
+	notRespondingSent     bool
+	recoveryInterval      time.Duration
+	lastRecoveryReconnect time.Time
+
+	// currentReset cancels the waiters of the most recent ping generation
+	currentReset atomic.Pointer[resetter]
+}
+
+func (pl *phoneLiveness) onLiveness() (notRespondingSent, wasFailing, needsCatchUp bool) {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+	notRespondingSent = pl.notRespondingSent
+	wasFailing = notRespondingSent || pl.timeouts > 0 || pl.sendFails > 0
+	needsCatchUp = notRespondingSent || pl.timeouts >= setActiveSessionAfterTimeouts
+	pl.firstPingDone = true
+	pl.notRespondingSent = false
+	pl.timeouts = 0
+	pl.sendFails = 0
+	pl.recoveryInterval = 0
+	return
+}
+
+func (pl *phoneLiveness) onTimeout(urgent bool, alertTimeoutCount int) (timeouts int, sendNotResponding bool) {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+	pl.timeouts++
+	timeouts = pl.timeouts
+	alert := !pl.firstPingDone || urgent || timeouts >= alertTimeoutCount
+	sendNotResponding = alert && !pl.notRespondingSent
+	if sendNotResponding {
+		pl.notRespondingSent = true
+	}
+	return
+}
+
+func (pl *phoneLiveness) shouldMarkNotResponding() bool {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+	if pl.notRespondingSent {
+		return false
+	}
+	pl.notRespondingSent = true
+	return true
+}
+
+func (pl *phoneLiveness) timeoutCount() int {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+	return pl.timeouts
+}
+
+func (pl *phoneLiveness) canDoRecovery() bool {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+	return pl.lastRecoveryReconnect.IsZero() || time.Since(pl.lastRecoveryReconnect) >= pl.recoveryInterval
+}
+
+func (pl *phoneLiveness) startRecovery() {
+	pl.lock.Lock()
+	pl.lastRecoveryReconnect = time.Now()
+	pl.lock.Unlock()
+}
+
+func (pl *phoneLiveness) getRecoveryInterval() time.Duration {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+	if pl.recoveryInterval == 0 {
+		pl.recoveryInterval = initialRecoveryInterval
+	}
+	return pl.recoveryInterval
+}
+
+func (pl *phoneLiveness) advanceRecoveryInterval() {
+	pl.lock.Lock()
+	if pl.recoveryInterval < maxRepingTickerTime {
+		pl.recoveryInterval *= 2
+	}
+	pl.lock.Unlock()
+}
 
 // Goals of the ditto pinger:
 //   - By default, send pings to the phone every minute
@@ -39,22 +136,24 @@ var pingIDCounter atomic.Uint64
 //   - If the first ping doesn't respond, send PhoneNotResponding
 //     (to avoid the bridge being stuck in the CONNECTING state)
 //   - If a ping doesn't respond, send new pings on increasing intervals
-//     (starting from 1 minute up to 1 hour) until it responds
+//     (starting from 1 minute up to 1 hour) until it responds, escalating to re-arming the
+//     phone's event subscription and then to reconnecting, since those recover the cases
+//     that pinging alone never will
 //   - If a normal ping doesn't respond, send PhoneNotResponding after 3 failed pings
 //     (so after ~8 minutes in total, not faster to avoid unnecessarily spamming the user)
 //   - If a request timeout happens during backoff pings, send PhoneNotResponding immediately
-//   - If a ping responds and PhoneNotResponding was sent, send PhoneRespondingAgain
+//   - If a ping responds, or any data arrives from the phone, and PhoneNotResponding was
+//     sent, send PhoneRespondingAgain
+//
+// Waiting for pings never happens on the pinger's own goroutine: while the phone is
+// unresponsive the loop still has to run data receive checks, which are the only thing
+// that notices silently stalled event delivery.
 type dittoPinger struct {
 	client *Client
 
-	firstPingDone     bool
-	pingHandlingLock  sync.RWMutex
-	oldestPingTime    time.Time
-	lastPingTime      time.Time
-	pingFails         int
-	notRespondingSent bool
 	pingInterval      time.Duration
 	alertTimeoutCount int
+	recovering        atomic.Bool
 
 	stop <-chan struct{}
 	log  *zerolog.Logger
@@ -81,190 +180,247 @@ func (r *resetter) Done() {
 }
 
 func (dp *dittoPinger) OnRespond(pingID uint64, dur time.Duration, reset *resetter) {
-	dp.pingHandlingLock.Lock()
-	defer dp.pingHandlingLock.Unlock()
+	notRespondingSent, wasFailing, needsCatchUp := dp.client.phone.onLiveness()
 	logEvt := dp.log.Debug().Uint64("ping_id", pingID).Dur("duration", dur)
-	if dp.notRespondingSent {
+	switch {
+	case notRespondingSent:
 		logEvt.Msg("Ditto ping successful (phone is back online)")
-		dp.client.triggerEvent(&events.PhoneRespondingAgain{})
-	} else if dp.pingFails > 0 {
+	case wasFailing:
 		logEvt.Msg("Ditto ping successful (stopped failing)")
-		// TODO separate event?
-		dp.client.triggerEvent(&events.PhoneRespondingAgain{})
-	} else {
+	default:
 		logEvt.Msg("Ditto ping successful")
 	}
-	dp.oldestPingTime = time.Time{}
-	dp.notRespondingSent = false
-	dp.pingFails = 0
-	dp.firstPingDone = true
+	if wasFailing {
+		// TODO separate event for the case where PhoneNotResponding was never sent?
+		dp.client.triggerEvent(&events.PhoneRespondingAgain{})
+	}
+	if needsCatchUp {
+		go dp.client.requestUpdatesAfterGap(dp.log, "phone started responding to pings again")
+	}
 	reset.Done()
 }
 
-func (dp *dittoPinger) OnTimeout(pingID uint64, sendNotResponding bool) {
-	dp.pingHandlingLock.Lock()
-	defer dp.pingHandlingLock.Unlock()
-	dp.log.Warn().Uint64("ping_id", pingID).Msg("Ditto ping is taking long, phone may be offline")
-	if (!dp.firstPingDone || sendNotResponding) && !dp.notRespondingSent {
+func (dp *dittoPinger) OnTimeout(pingID uint64, urgent bool, reset *resetter) {
+	timeouts, sendNotResponding := dp.client.phone.onTimeout(urgent, dp.alertTimeoutCount)
+	dp.log.Warn().
+		Uint64("ping_id", pingID).
+		Int("timeout_count", timeouts).
+		Msg("Ditto ping is taking long, phone may be offline")
+	if sendNotResponding {
 		dp.client.triggerEvent(&events.PhoneNotResponding{})
-		dp.notRespondingSent = true
 	}
+	dp.startRecovery(reset)
 }
 
-func (dp *dittoPinger) WaitForResponse(pingID uint64, start time.Time, timeout time.Duration, timeoutCount int, pingChan <-chan *IncomingRPCMessage, reset *resetter) {
-	var timerChan <-chan time.Time
-	var timer *time.Timer
-	if timeout > 0 {
-		timer = time.NewTimer(timeout)
-		timerChan = timer.C
-	}
+type pendingPing struct {
+	id        uint64
+	requestID string
+	start     time.Time
+	ch        chan *IncomingRPCMessage
+}
+
+func (dp *dittoPinger) WaitForResponse(ping pendingPing, timeout time.Duration, reset *resetter) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
-	case <-pingChan:
-		dp.OnRespond(pingID, time.Since(start), reset)
-		if timer != nil && !timer.Stop() {
-			<-timer.C
-		}
-	case <-timerChan:
-		dp.OnTimeout(pingID, timeout == shortPingTimeout || timeoutCount >= dp.alertTimeoutCount)
-		repingTickerTime := 1 * time.Minute
-		var repingTicker *time.Ticker
-		var repingTickerChan <-chan time.Time
-		if timeoutCount == 0 {
-			repingTicker = time.NewTicker(repingTickerTime)
-			repingTickerChan = repingTicker.C
-		}
-		for {
-			timeoutCount++
-			select {
-			case <-pingChan:
-				dp.OnRespond(pingID, time.Since(start), reset)
-				return
-			case <-repingTickerChan:
-				if repingTickerTime < maxRepingTickerTime {
-					repingTickerTime *= 2
-					repingTicker.Reset(repingTickerTime)
-				}
-				subPingID := pingIDCounter.Add(1)
-				dp.log.Debug().
-					Uint64("parent_ping_id", pingID).
-					Uint64("ping_id", subPingID).
-					Str("next_reping", repingTickerTime.String()).
-					Msg("Sending new ping")
-				dp.Ping(subPingID, defaultPingTimeout, timeoutCount, reset)
-			case <-dp.client.pingShortCircuit:
-				dp.pingHandlingLock.Lock()
-				dp.log.Debug().Uint64("ping_id", pingID).
-					Msg("Ditto ping wait short-circuited during ping backoff, sending PhoneNotResponding immediately")
-				if !dp.notRespondingSent {
-					dp.client.triggerEvent(&events.PhoneNotResponding{})
-					dp.notRespondingSent = true
-				}
-				dp.pingHandlingLock.Unlock()
-			case <-dp.stop:
-				return
-			case <-reset.C:
-				dp.log.Debug().
-					Uint64("ping_id", pingID).
-					Msg("Another ping was successful, giving up on this one")
-				return
-			}
-		}
+	case <-ping.ch:
+		dp.OnRespond(ping.id, time.Since(ping.start), reset)
+		return
+	case <-timer.C:
+		dp.OnTimeout(ping.id, timeout == shortPingTimeout, reset)
 	case <-reset.C:
 		dp.log.Debug().
-			Uint64("ping_id", pingID).
+			Uint64("ping_id", ping.id).
 			Msg("Another ping was successful, giving up on this one")
-		if timer != nil && !timer.Stop() {
-			<-timer.C
-		}
 	case <-dp.stop:
-		if timer != nil && !timer.Stop() {
-			<-timer.C
-		}
 	}
+	// Stop waiting for the response, but leave detecting a late one to onPhoneActivity:
+	// the phone answering at all is what matters, not which request it was answering.
+	dp.client.sessionHandler.cancelResponse(ping.requestID, ping.ch)
 }
 
-func (dp *dittoPinger) Ping(pingID uint64, timeout time.Duration, timeoutCount int, reset *resetter) {
-	dp.pingHandlingLock.Lock()
-	if time.Since(dp.lastPingTime) < minPingInterval {
+func (dp *dittoPinger) Ping(pingID uint64, timeout time.Duration, reset *resetter) {
+	pl := &dp.client.phone
+	pl.lock.Lock()
+	if time.Since(pl.lastPingTime) < minPingInterval {
 		dp.log.Debug().
 			Uint64("ping_id", pingID).
-			Time("last_ping_time", dp.lastPingTime).
+			Time("last_ping_time", pl.lastPingTime).
 			Msg("Skipping ping since last one was too recently")
-		dp.pingHandlingLock.Unlock()
+		pl.lock.Unlock()
 		return
 	}
 	now := time.Now()
-	dp.lastPingTime = now
-	if dp.oldestPingTime.IsZero() {
-		dp.oldestPingTime = now
-	}
-	pingChan, err := dp.client.NotifyDittoActivity(dp.log.WithContext(context.TODO()))
+	pl.lastPingTime = now
+	pl.lock.Unlock()
+
+	// Publish the generation only for pings that are actually sent, so data from the phone
+	// always cancels the waiters that are really outstanding.
+	pl.currentReset.Store(reset)
+
+	pingChan, requestID, err := dp.client.notifyDittoActivity(dp.log.WithContext(context.TODO()))
 	if err != nil {
+		pl.lock.Lock()
+		pl.sendFails++
+		sendFails := pl.sendFails
+		pl.lock.Unlock()
 		dp.log.Err(err).Uint64("ping_id", pingID).Msg("Error sending ping")
-		dp.pingFails++
 		dp.client.triggerEvent(&events.PingFailed{
 			Error:      fmt.Errorf("failed to notify ditto activity: %w", err),
-			ErrorCount: dp.pingFails,
+			ErrorCount: sendFails,
 		})
-		dp.pingHandlingLock.Unlock()
 		return
 	}
-	dp.pingHandlingLock.Unlock()
-	if timeoutCount == 0 {
-		dp.WaitForResponse(pingID, now, timeout, timeoutCount, pingChan, reset)
-	} else {
-		go dp.WaitForResponse(pingID, now, timeout, timeoutCount, pingChan, reset)
+	go dp.WaitForResponse(pendingPing{
+		id:        pingID,
+		requestID: requestID,
+		start:     now,
+		ch:        pingChan,
+	}, timeout, reset)
+}
+
+// startRecovery hands an unresponsive phone off to a background goroutine, unless recovery
+// is already running.
+func (dp *dittoPinger) startRecovery(reset *resetter) {
+	if dp.recovering.CompareAndSwap(false, true) {
+		go dp.recoveryLoop(reset)
+	}
+}
+
+// recoveryLoop re-pings an unresponsive phone on increasing intervals, escalating to
+// session-level recovery as the failures add up: first re-arming the phone's event
+// subscription, then reconnecting to get a new listener session. Reconnects are rate
+// limited to the current backoff interval, so a phone that stays offline for hours is
+// probed less and less often rather than being reconnected in a loop.
+func (dp *dittoPinger) recoveryLoop(reset *resetter) {
+	defer dp.recovering.Store(false)
+	pl := &dp.client.phone
+	didSetActiveSession := false
+	for {
+		select {
+		case <-time.After(pl.getRecoveryInterval()):
+		case <-reset.C:
+			dp.log.Debug().Msg("Phone responded, stopping ditto ping recovery")
+			return
+		case <-dp.stop:
+			return
+		}
+		// The connection may have been torn down while waiting, in which case recovering it
+		// would resurrect a client the bridge has already disconnected.
+		select {
+		case <-dp.stop:
+			return
+		default:
+		}
+		timeouts := pl.timeoutCount()
+		if timeouts == 0 {
+			dp.log.Debug().Msg("Phone is responding again, stopping ditto ping recovery")
+			return
+		}
+		ctx := dp.log.WithContext(context.TODO())
+		switch {
+		case timeouts >= reconnectAfterTimeouts && pl.canDoRecovery():
+			dp.log.Warn().
+				Int("timeout_count", timeouts).
+				Msg("Phone hasn't responded to pings, reconnecting to get a new listener session")
+			pl.startRecovery()
+			if err := dp.client.Reconnect(); err != nil {
+				dp.log.Err(err).Msg("Failed to reconnect while recovering from ping timeouts")
+			} else {
+				// The reconnect replaces this connection's ping loop, including this
+				// recovery goroutine.
+				return
+			}
+		case timeouts >= setActiveSessionAfterTimeouts && !didSetActiveSession:
+			didSetActiveSession = true
+			dp.log.Warn().
+				Int("timeout_count", timeouts).
+				Msg("Phone hasn't responded to pings, re-arming its event subscription")
+			if err := dp.client.SetActiveSession(ctx); err != nil {
+				dp.log.Err(err).Msg("Failed to set active session while recovering from ping timeouts")
+			}
+		}
+		pl.advanceRecoveryInterval()
+		pingID := pingIDCounter.Add(1)
+		dp.log.Debug().
+			Uint64("ping_id", pingID).
+			Int("timeout_count", timeouts).
+			Msg("Sending recovery ping")
+		dp.Ping(pingID, defaultPingTimeout, reset)
 	}
 }
 
 const DefaultBugleDefaultCheckInterval = 2*time.Hour + 55*time.Minute
 
 func (dp *dittoPinger) Loop() {
-	var lastDataReceiveCheck time.Time
 	for {
-		var pingStart time.Time
 		select {
 		case <-dp.client.pingShortCircuit:
-			pingID := pingIDCounter.Add(1)
-			dp.log.Debug().Uint64("ping_id", pingID).Msg("Ditto ping wait short-circuited")
-			pingStart = time.Now()
-			dp.Ping(pingID, shortPingTimeout, 0, newResetter())
+			if dp.recovering.Load() {
+				// Recovery pings are already in flight, but the user is actively waiting
+				// for a request, so don't make them wait out the backoff for a notice.
+				dp.log.Debug().Msg("Ditto ping wait short-circuited during recovery, sending PhoneNotResponding immediately")
+				if dp.client.phone.shouldMarkNotResponding() {
+					dp.client.triggerEvent(&events.PhoneNotResponding{})
+				}
+			} else {
+				pingID := pingIDCounter.Add(1)
+				dp.log.Debug().Uint64("ping_id", pingID).Msg("Ditto ping wait short-circuited")
+				dp.Ping(pingID, shortPingTimeout, newResetter())
+			}
 		case <-time.After(dp.pingInterval):
-			pingID := pingIDCounter.Add(1)
-			dp.log.Trace().Uint64("ping_id", pingID).Msg("Doing normal ditto ping")
-			pingStart = time.Now()
-			dp.Ping(pingID, defaultPingTimeout, 0, newResetter())
+			if dp.recovering.Load() {
+				dp.log.Trace().Msg("Skipping normal ditto ping, recovery pings are already in progress")
+			} else {
+				pingID := pingIDCounter.Add(1)
+				dp.log.Trace().Uint64("ping_id", pingID).Msg("Doing normal ditto ping")
+				dp.Ping(pingID, defaultPingTimeout, newResetter())
+			}
 		case <-dp.stop:
 			return
 		}
 		if dp.client.shouldDoDataReceiveCheck() {
-			dp.log.Warn().
-				Time("last_data_receive_check", lastDataReceiveCheck).
-				Msg("No data received recently, sending extra GET_UPDATES call")
-			go dp.HandleNoRecentUpdates()
-			lastDataReceiveCheck = time.Now()
-		} else if time.Since(pingStart) > 5*time.Minute || (time.Since(pingStart) > 1*time.Minute && time.Since(lastDataReceiveCheck) > 30*time.Minute) {
-			dp.log.Warn().
-				Time("ping_start", pingStart).
-				Time("last_data_receive_check", lastDataReceiveCheck).
-				Msg("Was disconnected for over a minute, sending extra GET_UPDATES call")
-			go dp.HandleNoRecentUpdates()
-			lastDataReceiveCheck = time.Now()
+			dp.log.Warn().Msg("No data received recently, sending extra GET_UPDATES call")
+			go dp.client.requestUpdatesAfterGap(dp.log, "no data received recently")
 		}
 	}
 }
 
-func (dp *dittoPinger) HandleNoRecentUpdates() {
-	dp.client.triggerEvent(&events.NoDataReceived{})
-	err := dp.client.sessionHandler.sendMessageNoResponse(dp.log.WithContext(context.TODO()), SendMessageParams{
+// onPhoneActivity is called when data is received from the phone outside of the ditto pings and
+// is counted as liveness just like pings.
+func (c *Client) onPhoneActivity(source string) {
+	notRespondingSent, wasFailing, needsCatchUp := c.phone.onLiveness()
+	if !wasFailing {
+		return
+	}
+	c.Logger.Debug().
+		Str("liveness_source", source).
+		Bool("not_responding_sent", notRespondingSent).
+		Msg("Received data from phone while it was considered unresponsive")
+	// Stop any recovery ladder: the phone is reachable, so escalating to a reconnect
+	// would only interrupt a working connection.
+	if reset := c.phone.currentReset.Load(); reset != nil {
+		reset.Done()
+	}
+	if notRespondingSent {
+		c.triggerEvent(&events.PhoneRespondingAgain{})
+	}
+	if needsCatchUp {
+		go c.requestUpdatesAfterGap(&c.Logger, "phone started responding again")
+	}
+}
+
+func (c *Client) requestUpdatesAfterGap(log *zerolog.Logger, reason string) {
+	c.triggerEvent(&events.NoDataReceived{})
+	err := c.sessionHandler.sendMessageNoResponse(log.WithContext(context.TODO()), SendMessageParams{
 		Action:    gmproto.ActionType_GET_UPDATES,
 		OmitTTL:   true,
-		RequestID: dp.client.sessionHandler.sessionID,
+		RequestID: c.sessionHandler.sessionID,
 	})
 	if err != nil {
-		dp.log.Err(err).Msg("Failed to send extra GET_UPDATES call")
+		log.Err(err).Str("reason", reason).Msg("Failed to send extra GET_UPDATES call")
 	} else {
-		dp.log.Debug().Msg("Sent extra GET_UPDATES call")
+		log.Debug().Str("reason", reason).Msg("Sent extra GET_UPDATES call")
 	}
 }
 
@@ -317,6 +473,7 @@ func (c *Client) doLongPoll(loggedIn, background bool, onFirstConnect func()) bo
 	}
 
 	errorCount := 1
+	var disconnectedAt time.Time
 	for c.listenID == listenID {
 		err := c.refreshAuthToken(nil)
 		if err != nil {
@@ -414,6 +571,13 @@ func (c *Client) doLongPoll(loggedIn, background bool, onFirstConnect func()) bo
 		}
 		log.Debug().Int("statusCode", resp.StatusCode).Msg("Long polling opened")
 		c.longPollingConn = resp.Body
+		if loggedIn && !disconnectedAt.IsZero() && time.Since(disconnectedAt) > longPollGapCatchUp {
+			// Events the phone sent while the connection was down may not be redelivered.
+			log.Warn().
+				Time("disconnected_at", disconnectedAt).
+				Msg("Long polling was disconnected for a while, requesting updates")
+			go c.requestUpdatesAfterGap(&log, "long polling was disconnected")
+		}
 		if onFirstConnect != nil {
 			go onFirstConnect()
 			onFirstConnect = nil
@@ -423,6 +587,7 @@ func (c *Client) doLongPoll(loggedIn, background bool, onFirstConnect func()) bo
 		if background {
 			return cleanClose
 		}
+		disconnectedAt = time.Now()
 	}
 	return true
 }

--- a/pkg/libgm/methods.go
+++ b/pkg/libgm/methods.go
@@ -151,8 +151,8 @@ func (c *Client) IsBugleDefault(ctx context.Context) (*gmproto.IsBugleDefaultRes
 	return typedResponse[*gmproto.IsBugleDefaultResponse](c.sessionHandler.sendMessage(ctx, actionType, nil))
 }
 
-func (c *Client) NotifyDittoActivity(ctx context.Context) (<-chan *IncomingRPCMessage, error) {
-	return c.sessionHandler.sendAsyncMessage(ctx, SendMessageParams{
+func (c *Client) notifyDittoActivity(ctx context.Context) (chan *IncomingRPCMessage, string, error) {
+	return c.sessionHandler.sendAsyncMessageWithID(ctx, SendMessageParams{
 		Action: gmproto.ActionType_NOTIFY_DITTO_ACTIVITY,
 		Data:   &gmproto.NotifyDittoActivityRequest{Success: true},
 	})

--- a/pkg/libgm/session_handler.go
+++ b/pkg/libgm/session_handler.go
@@ -168,6 +168,10 @@ func (s *SessionHandler) receiveResponse(msg *IncomingRPCMessage) bool {
 	}
 	delete(s.responseWaiters, requestID)
 	s.responseWaitersLock.Unlock()
+	// Ditto activity is handled by the pinger directly
+	if msg.Message.Action != gmproto.ActionType_NOTIFY_DITTO_ACTIVITY {
+		s.client.onPhoneActivity("request response")
+	}
 	evt := s.client.Logger.Debug().
 		Str("request_message_id", requestID).
 		Str("response_message_id", msg.ResponseID)


### PR DESCRIPTION
Refactors the pinger/phone liveness detection to count any incoming data as liveness and use a stepped recovery path that first pings and later attempts to re-arm the session with the phone automatically.

This is based on reports where the phone is alive and re-linking the bridge fixes it, in theory this automates that re-link.
