### PR TITLE
connector,libgm: re-resolve destination registration on gaia logout

### DIFF
--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -129,10 +129,7 @@ func (gc *GMClient) handleGMEvent(rawEvt any) {
 		//go gc.sendMarkdownBridgeAlert(ctx, true, "Unpaired from Google Messages. Log in again to continue using the bridge.")
 	case *events.GaiaLoggedOut:
 		log.Info().Msg("Got gaia logout event")
-		go gc.invalidateSession(ctx, status.BridgeState{
-			StateEvent: status.StateBadCredentials,
-			Error:      GMUnpaired,
-		}, true)
+		go gc.handleGaiaLoggedOut(ctx)
 		//go gc.sendMarkdownBridgeAlert(ctx, true, "Unpaired from Google Messages. Log in again to continue using the bridge.")
 	case *events.AuthTokenRefreshed:
 		go func() {
@@ -400,6 +397,31 @@ func (gc *GMClient) handleSettings(ctx context.Context, settings *gmproto.Settin
 		}
 		gc.UserLogin.BridgeState.Send(status.BridgeState{StateEvent: status.StateConnected})
 	}
+}
+
+// handleGaiaLoggedOut checks whether the phone simply re-registered before treating the logout
+// marker as a real logout: the marker is also sent when the destination registration rotates, in
+// which case the existing credentials still work against the new registration.
+func (gc *GMClient) handleGaiaLoggedOut(ctx context.Context) {
+	log := zerolog.Ctx(ctx)
+	if cli := gc.Client; cli != nil {
+		changed, err := cli.RefreshDestRegID(ctx)
+		if err != nil {
+			log.Err(err).Msg("Failed to re-resolve destination registration after gaia logout event")
+		} else if changed {
+			if err := gc.UserLogin.Save(ctx); err != nil {
+				log.Err(err).Msg("Failed to save updated destination registration")
+			}
+			cli.FlushAcks()
+			gc.ResetClient()
+			gc.Connect(ctx)
+			return
+		}
+	}
+	gc.invalidateSession(ctx, status.BridgeState{
+		StateEvent: status.StateBadCredentials,
+		Error:      GMUnpaired,
+	}, true)
 }
 
 func (gc *GMClient) invalidateSession(ctx context.Context, state status.BridgeState, deleteFull bool) {

--- a/pkg/libgm/client.go
+++ b/pkg/libgm/client.go
@@ -311,6 +311,12 @@ func (c *Client) Disconnect() {
 	c.http.CloseIdleConnections()
 }
 
+// FlushAcks sends any queued message acks immediately. Queued acks are lost when the client is
+// replaced, which makes the server redeliver the messages on the next connection.
+func (c *Client) FlushAcks() {
+	c.sessionHandler.sendAckRequest()
+}
+
 func (c *Client) IsConnected() bool {
 	// TODO add better check (longPollingConn is set to nil while the polling reconnects)
 	return c.longPollingConn != nil

--- a/pkg/libgm/pair_google.go
+++ b/pkg/libgm/pair_google.go
@@ -285,6 +285,7 @@ func (ps *PairingSession) ProcessServerInit(msg *gmproto.GaiaPairingResponseCont
 
 var (
 	ErrNoCookies          = errors.New("gaia pairing requires cookies")
+	ErrNotGoogleAccount   = errors.New("not a google account")
 	ErrNoDevicesFound     = errors.New("no devices found for gaia pairing")
 	ErrIncorrectEmoji     = errors.New("user chose incorrect emoji on phone")
 	ErrPairingCancelled   = errors.New("user cancelled pairing on phone")
@@ -326,20 +327,7 @@ func (c *Client) DoGaiaPairing(ctx context.Context, emojiCallback func(string)) 
 	return nil
 }
 
-func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession, error) {
-	if !c.AuthData.HasCookies() {
-		return "", nil, ErrNoCookies
-	}
-	sigResp, err := c.signInGaiaGetToken(ctx)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to prepare gaia pairing: %w", err)
-	}
-	// Don't log the whole object as it also contains the tachyon token
-	zerolog.Ctx(ctx).Debug().
-		Any("header", sigResp.Header).
-		Str("maybe_browser_uuid", sigResp.MaybeBrowserUUID).
-		Any("device_data", sigResp.DeviceData).
-		Msg("Gaia devices response")
+func (c *Client) selectPrimaryDevice(ctx context.Context, sigResp *gmproto.SignInGaiaResponse) (device *primaryDeviceID, deviceCount int, err error) {
 	var primaryDevices []*primaryDeviceID
 	primaryDeviceMap := make(map[string]*primaryDeviceID)
 	for _, dev := range sigResp.GetDeviceData().GetUnknownItems2() {
@@ -358,7 +346,7 @@ func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession,
 		}
 	}
 	if len(primaryDevices) == 0 {
-		return "", nil, ErrNoDevicesFound
+		return nil, 0, ErrNoDevicesFound
 	} else if len(primaryDevices) > 1 {
 		// Sort by last seen time, newest first
 		slices.SortFunc(primaryDevices, func(a, b *primaryDeviceID) int {
@@ -375,6 +363,60 @@ func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession,
 		Uint64("dest_reg_unknown_int", destRegDev.UnknownInt).
 		Time("dest_reg_last_seen", destRegDev.LastSeen).
 		Msg("Found UUID to use for gaia pairing")
+	return destRegDev, len(primaryDevices), nil
+}
+
+// RefreshDestRegID re-fetches the Google account's device list and updates the stored destination
+// registration if the phone has re-registered. It reports whether the registration changed.
+func (c *Client) RefreshDestRegID(ctx context.Context) (bool, error) {
+	if !c.AuthData.IsGoogleAccount() {
+		return false, ErrNotGoogleAccount
+	} else if !c.AuthData.HasCookies() {
+		return false, ErrNoCookies
+	}
+	sigResp, err := c.signInGaiaGetToken(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch device list: %w", err)
+	} else if sigResp.GetTokenData().GetTachyonAuthToken() == nil {
+		return false, fmt.Errorf("no tachyon auth token in device list response")
+	}
+	destRegDev, _, err := c.selectPrimaryDevice(ctx, sigResp)
+	if err != nil {
+		return false, err
+	}
+	destRegUUID, err := uuid.Parse(destRegDev.RegID)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse destination UUID: %w", err)
+	}
+	if destRegUUID == c.AuthData.DestRegID {
+		return false, nil
+	}
+	zerolog.Ctx(ctx).Info().
+		Stringer("old_dest_reg_uuid", c.AuthData.DestRegID).
+		Stringer("new_dest_reg_uuid", destRegUUID).
+		Msg("Destination registration rotated")
+	c.AuthData.DestRegID = destRegUUID
+	return true, nil
+}
+
+func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession, error) {
+	if !c.AuthData.HasCookies() {
+		return "", nil, ErrNoCookies
+	}
+	sigResp, err := c.signInGaiaGetToken(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to prepare gaia pairing: %w", err)
+	}
+	// Don't log the whole object as it also contains the tachyon token
+	zerolog.Ctx(ctx).Debug().
+		Any("header", sigResp.Header).
+		Str("maybe_browser_uuid", sigResp.MaybeBrowserUUID).
+		Any("device_data", sigResp.DeviceData).
+		Msg("Gaia devices response")
+	destRegDev, deviceCount, err := c.selectPrimaryDevice(ctx, sigResp)
+	if err != nil {
+		return "", nil, err
+	}
 	destRegUUID, err := uuid.Parse(destRegDev.RegID)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to parse destination UUID: %w", err)
@@ -399,7 +441,7 @@ func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession,
 		}
 		if errors.Is(err, context.DeadlineExceeded) {
 			err = ErrPairingInitTimeout
-			if len(primaryDevices) > 1 {
+			if deviceCount > 1 {
 				err = fmt.Errorf("%w (%w)", ErrPairingInitTimeout, ErrHadMultipleDevices)
 			}
 			return "", nil, err


### PR DESCRIPTION
Google rotates the phone's destination registration roughly daily and pushes the logout marker, which destroyed the entire saved session including the still valid Google cookies.

Re-fetch the device list when the marker arrives and reconnect in place if only the registration changed, falling back to invalidating the session otherwise. Flush queued acks before replacing the client so the server does not redeliver the marker.
