### PR TITLE
connector: explain gaia logouts caused by a competing web session

### DIFF
--- a/pkg/connector/bridgestate.go
+++ b/pkg/connector/bridgestate.go
@@ -26,6 +26,7 @@ const (
 	GMListenError               status.BridgeStateErrorCode = "gm-listen-error"
 	GMFatalError                status.BridgeStateErrorCode = "gm-listen-fatal-error"
 	GMUnpaired                  status.BridgeStateErrorCode = "gm-unpaired"
+	GMUnpairedGaia              status.BridgeStateErrorCode = "gm-unpaired-gaia"
 	GMUnpaired404               status.BridgeStateErrorCode = "gm-unpaired-entity-not-found"
 	GMLoggedOut401              status.BridgeStateErrorCode = "gm-logged-out-401-polling"
 	GMLoggedOutInvalidCreds     status.BridgeStateErrorCode = "gm-logged-out-invalid-credentials"
@@ -52,6 +53,7 @@ func init() {
 		GMNotLoggedIn:               "Unpaired from Google Messages, please re-link the connection to continue using SMS/RCS",
 		GMNotLoggedInCanReauth:      "Unpaired from Google Messages, please re-link the connection to continue using SMS/RCS",
 		GMUnpaired:                  "Unpaired from Google Messages, please re-link the connection to continue using SMS/RCS",
+		GMUnpairedGaia:              "Google Messages signed this connection out. This usually happens when the same Google account is linked to Google Messages for web somewhere else (another Beeper account or a browser) — Google only keeps one connected. Re-link to continue using SMS/RCS.",
 		GMUnpaired404:               "Unpaired from Google Messages, please re-link the connection to continue using SMS/RCS",
 		GMLoggedOut401:              "Unpaired from Google Messages, please re-link the connection to continue using SMS/RCS",
 		GMLoggedOutInvalidCreds:     "Unpaired from Google Messages, please re-link the connection to continue using SMS/RCS",

--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -129,9 +129,13 @@ func (gc *GMClient) handleGMEvent(rawEvt any) {
 		//go gc.sendMarkdownBridgeAlert(ctx, true, "Unpaired from Google Messages. Log in again to continue using the bridge.")
 	case *events.GaiaLoggedOut:
 		log.Info().Msg("Got gaia logout event")
+		errCode := GMUnpaired
+		if sess := gc.Meta.Session; sess != nil && !sess.OtherWebSessionAtPairing.IsZero() {
+			errCode = GMUnpairedGaia
+		}
 		go gc.invalidateSession(ctx, status.BridgeState{
 			StateEvent: status.StateBadCredentials,
-			Error:      GMUnpaired,
+			Error:      errCode,
 		}, true)
 		//go gc.sendMarkdownBridgeAlert(ctx, true, "Unpaired from Google Messages. Log in again to continue using the bridge.")
 	case *events.AuthTokenRefreshed:

--- a/pkg/libgm/client.go
+++ b/pkg/libgm/client.go
@@ -43,6 +43,9 @@ type AuthData struct {
 	DestRegID uuid.UUID `json:"dest_reg_id,omitempty"`
 	PairingID uuid.UUID `json:"pairing_id,omitempty"`
 
+	// Last seen time of the newest other Messages-for-web session on the account when this session was paired
+	OtherWebSessionAtPairing time.Time `json:"other_web_session_at_pairing,omitempty"`
+
 	Cookies     map[string]string `json:"cookies,omitempty"`
 	CookiesLock sync.RWMutex      `json:"-"`
 }

--- a/pkg/libgm/pair_google.go
+++ b/pkg/libgm/pair_google.go
@@ -295,6 +295,13 @@ var (
 
 const GaiaInitTimeout = 20 * time.Second
 
+const (
+	gaiaDeviceTypePhone      = 1
+	gaiaDeviceTypeWebSession = 6
+)
+
+const otherWebSessionMaxAge = 24 * time.Hour
+
 type primaryDeviceID struct {
 	RegID      string
 	UnknownInt uint64
@@ -342,21 +349,37 @@ func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession,
 		Msg("Gaia devices response")
 	var primaryDevices []*primaryDeviceID
 	primaryDeviceMap := make(map[string]*primaryDeviceID)
+	otherWebSessions := make(map[string]struct{})
+	ownWebSessionUUID := sigResp.GetMaybeBrowserUUID()
 	for _, dev := range sigResp.GetDeviceData().GetUnknownItems2() {
-		if dev.GetUnknownInt4() == 1 {
+		switch dev.GetUnknownInt4() {
+		case gaiaDeviceTypePhone:
 			pd := &primaryDeviceID{
 				RegID:      dev.GetDestOrSourceUUID(),
 				UnknownInt: dev.GetUnknownBigInt7(),
 			}
 			primaryDeviceMap[pd.RegID] = pd
 			primaryDevices = append(primaryDevices, pd)
+		case gaiaDeviceTypeWebSession:
+			if ownWebSessionUUID != "" && dev.GetDestOrSourceUUID() != ownWebSessionUUID {
+				otherWebSessions[dev.GetDestOrSourceUUID()] = struct{}{}
+			}
 		}
 	}
+	var newestOtherWebSession time.Time
 	for _, dev := range sigResp.GetDeviceData().GetUnknownItems3() {
 		if pd, ok := primaryDeviceMap[dev.GetDestOrSourceUUID()]; ok {
 			pd.LastSeen = time.UnixMicro(dev.GetUnknownTimestampMicroseconds())
+		} else if _, isOther := otherWebSessions[dev.GetDestOrSourceUUID()]; isOther {
+			if lastSeen := time.UnixMicro(dev.GetUnknownTimestampMicroseconds()); lastSeen.After(newestOtherWebSession) {
+				newestOtherWebSession = lastSeen
+			}
 		}
 	}
+	if newestOtherWebSession.Before(time.Now().Add(-otherWebSessionMaxAge)) {
+		newestOtherWebSession = time.Time{}
+	}
+	c.AuthData.OtherWebSessionAtPairing = newestOtherWebSession
 	if len(primaryDevices) == 0 {
 		return "", nil, ErrNoDevicesFound
 	} else if len(primaryDevices) > 1 {
@@ -374,6 +397,7 @@ func (c *Client) StartGaiaPairing(ctx context.Context) (string, *PairingSession,
 		Str("dest_reg_uuid", destRegDev.RegID).
 		Uint64("dest_reg_unknown_int", destRegDev.UnknownInt).
 		Time("dest_reg_last_seen", destRegDev.LastSeen).
+		Time("other_web_session_last_seen", c.AuthData.OtherWebSessionAtPairing).
 		Msg("Found UUID to use for gaia pairing")
 	destRegUUID, err := uuid.Parse(destRegDev.RegID)
 	if err != nil {


### PR DESCRIPTION
Google only keeps one Messages-for-web session per account connected, so a second Beeper login on the same Google account gets silently revoked and the generic unpaired error sends the user back into a re-pair loop.

Record the last seen time of any other recently active web session found during gaia pairing, and report gaia logouts as gm-unpaired-gaia with an explanation when one was present.
