### PR TITLE
connector: match remote echoes without tmpID to recent sends

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -72,6 +72,9 @@ type GMClient struct {
 	conversationMeta     map[string]*conversationMeta
 	conversationMetaLock sync.Mutex
 
+	pendingSends     []*pendingSend
+	pendingSendsLock sync.Mutex
+
 	contactsFetchLock sync.Mutex
 	contactsFetchedAt time.Time
 	cachedContacts    []*bridgev2.ResolveIdentifierResponse

--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -18,9 +18,7 @@ package connector
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -734,7 +732,22 @@ func (m *MessageEvent) GetID() networkid.MessageID {
 }
 
 func (m *MessageEvent) GetTransactionID() networkid.TransactionID {
-	return networkid.TransactionID(m.TmpID)
+	if m.TmpID != "" {
+		return networkid.TransactionID(m.TmpID)
+	} else if m.IsOld {
+		return ""
+	}
+	// The server doesn't always echo the tmpID back, so fall back to matching the message against
+	// recently sent messages to avoid duplicating outgoing messages into the Matrix room.
+	txnID := m.g.matchPendingSend(m.Message)
+	if txnID != "" {
+		m.g.UserLogin.Log.Debug().
+			Str("message_id", m.MessageID).
+			Str("conversation_id", m.ConversationID).
+			Str("tmp_id", string(txnID)).
+			Msg("Matched message without tmpID to a recently sent message")
+	}
+	return txnID
 }
 
 func (m *MessageEvent) GetTargetMessage() networkid.MessageID {
@@ -754,9 +767,6 @@ func getTextPart(msg *gmproto.Message) (*bridgev2.ConvertedMessagePart, string) 
 	content := &event.MessageEventContent{
 		MsgType: event.MsgText,
 	}
-	textHasher := sha256.New()
-	textHasher.Write([]byte(msg.GetSubject()))
-	textHasher.Write([]byte{0x00})
 	if msg.GetSubject() != "" {
 		content.Format = event.FormatHTML
 		content.Body = fmt.Sprintf("\n**%s**", msg.GetSubject())
@@ -767,8 +777,6 @@ func getTextPart(msg *gmproto.Message) (*bridgev2.ConvertedMessagePart, string) 
 		if !ok {
 			continue
 		}
-		textHasher.Write([]byte(data.MessageContent.GetContent()))
-		textHasher.Write([]byte{0x00})
 		content.Body = fmt.Sprintf("%s\n%s", content.Body, data.MessageContent.GetContent())
 		if content.Format == event.FormatHTML {
 			content.FormattedBody += fmt.Sprintf("<br>%s", event.TextToHTML(data.MessageContent.GetContent()))
@@ -777,7 +785,7 @@ func getTextPart(msg *gmproto.Message) (*bridgev2.ConvertedMessagePart, string) 
 	content.Body = strings.TrimPrefix(content.Body, "\n")
 	var textHash string
 	if len(content.Body) > 0 {
-		textHash = hex.EncodeToString(textHasher.Sum(nil))
+		textHash = hashMessageText(msg.GetSubject(), msg.GetMessageInfo())
 	}
 	downloadStatus := downloadPendingStatusMessage(msg.GetMessageStatus().GetStatus())
 	if len(downloadStatus) > 0 {

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -63,6 +63,7 @@ func (gc *GMClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Matri
 		return nil, err
 	}
 	msg.AddPendingToSave(nil, txnID, gc.handleRemoteEcho)
+	gc.addPendingSend(txnID, req)
 	zerolog.Ctx(ctx).Debug().
 		Str("tmp_id", string(txnID)).
 		Str("participant_id", req.GetMessagePayload().GetParticipantID()).
@@ -79,9 +80,11 @@ func (gc *GMClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Matri
 				WithSendNotice(true)
 		}
 		msg.RemovePending(txnID)
+		gc.removePendingSend(txnID)
 		return nil, err
 	} else if resp.Status != gmproto.SendMessageResponse_SUCCESS {
 		msg.RemovePending(txnID)
+		gc.removePendingSend(txnID)
 		return nil, bridgev2.WrapErrorInStatus((*responseStatusError)(resp)).
 			WithIsCertain(true).WithSendNotice(true).WithErrorAsMessage()
 	}

--- a/pkg/connector/pendingsend.go
+++ b/pkg/connector/pendingsend.go
@@ -1,0 +1,132 @@
+// mautrix-gmessages - A Matrix-Google Messages puppeting bridge.
+// Copyright (C) 2024 Tulir Asokan
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package connector
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+
+	"maunium.net/go/mautrix/bridgev2/networkid"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+)
+
+// Google Messages normally echoes the tmpID that was passed in SendMessageRequest back in the
+// message events for that message, which is how outgoing messages are matched to the Matrix event
+// that caused them. However, the server sometimes stops filling the field entirely, which makes
+// every message sent from Matrix come back as if it was a new message sent from the phone, causing
+// the bridge to duplicate it into the Matrix room.
+//
+// To recover from that, recently sent messages are remembered here and matched against incoming
+// echoes by conversation and content when the echo has no tmpID.
+const (
+	// pendingSendTTL is how long a sent message can be matched against a tmpID-less echo.
+	pendingSendTTL = 60 * time.Second
+	// maxPendingSends is a hard cap on remembered sends to bound memory usage if echoes stop arriving.
+	maxPendingSends = 100
+)
+
+type pendingSend struct {
+	txnID    networkid.TransactionID
+	convID   string
+	textHash string
+	sentAt   time.Time
+}
+
+// hashMessageText hashes the text content of a message. The same hash is computed for outgoing
+// requests and incoming messages, so it can be used to match the two together.
+func hashMessageText(subject string, parts []*gmproto.MessageInfo) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(subject))
+	hasher.Write([]byte{0x00})
+	for _, part := range parts {
+		data, ok := part.Data.(*gmproto.MessageInfo_MessageContent)
+		if !ok {
+			continue
+		}
+		hasher.Write([]byte(data.MessageContent.GetContent()))
+		hasher.Write([]byte{0x00})
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// expireOldPendingSends drops entries that are too old to be matched anymore.
+// The caller must hold pendingSendsLock.
+func (gc *GMClient) expireOldPendingSends(now time.Time) {
+	firstValid := 0
+	for firstValid < len(gc.pendingSends) && now.Sub(gc.pendingSends[firstValid].sentAt) > pendingSendTTL {
+		firstValid++
+	}
+	gc.pendingSends = gc.pendingSends[firstValid:]
+	if len(gc.pendingSends) > maxPendingSends {
+		gc.pendingSends = gc.pendingSends[len(gc.pendingSends)-maxPendingSends:]
+	}
+}
+
+// addPendingSend remembers a message that was just sent, so that an echo without a tmpID can still
+// be matched back to the Matrix event that caused it.
+func (gc *GMClient) addPendingSend(txnID networkid.TransactionID, req *gmproto.SendMessageRequest) {
+	entry := &pendingSend{
+		txnID:    txnID,
+		convID:   req.GetConversationID(),
+		textHash: hashMessageText("", req.GetMessagePayload().GetMessageInfo()),
+		sentAt:   time.Now(),
+	}
+	gc.pendingSendsLock.Lock()
+	defer gc.pendingSendsLock.Unlock()
+	gc.expireOldPendingSends(entry.sentAt)
+	gc.pendingSends = append(gc.pendingSends, entry)
+}
+
+// removePendingSend forgets a message that turned out not to have been sent.
+func (gc *GMClient) removePendingSend(txnID networkid.TransactionID) {
+	gc.pendingSendsLock.Lock()
+	defer gc.pendingSendsLock.Unlock()
+	for i, entry := range gc.pendingSends {
+		if entry.txnID == txnID {
+			gc.pendingSends = append(gc.pendingSends[:i], gc.pendingSends[i+1:]...)
+			return
+		}
+	}
+}
+
+// matchPendingSend finds the transaction ID of the message that the given echo is most likely a
+// remote echo of. It returns an empty string if the message isn't an outgoing one or if there's no
+// recently sent message with the same content in the same conversation.
+//
+// A match is consumed, as only the first echo for a message needs to resolve the pending event.
+func (gc *GMClient) matchPendingSend(msg *gmproto.Message) networkid.TransactionID {
+	status := msg.GetMessageStatus().GetStatus()
+	// Statuses between 1 and 99 are outgoing types. Anything else was not sent by us.
+	if status < 1 || status >= 100 {
+		return ""
+	}
+	textHash := hashMessageText(msg.GetSubject(), msg.GetMessageInfo())
+	gc.pendingSendsLock.Lock()
+	defer gc.pendingSendsLock.Unlock()
+	gc.expireOldPendingSends(time.Now())
+	// The oldest match is used, as messages are echoed in the order they were sent.
+	for i, entry := range gc.pendingSends {
+		if entry.convID != msg.GetConversationID() || entry.textHash != textHash {
+			continue
+		}
+		gc.pendingSends = append(gc.pendingSends[:i], gc.pendingSends[i+1:]...)
+		return entry.txnID
+	}
+	return ""
+}

--- a/pkg/connector/pendingsend_test.go
+++ b/pkg/connector/pendingsend_test.go
@@ -1,0 +1,110 @@
+package connector
+
+import (
+	"testing"
+
+	"maunium.net/go/mautrix/bridgev2/networkid"
+
+	"go.mau.fi/mautrix-gmessages/pkg/libgm/gmproto"
+)
+
+func textPayload(texts ...string) []*gmproto.MessageInfo {
+	parts := make([]*gmproto.MessageInfo, len(texts))
+	for i, text := range texts {
+		parts[i] = &gmproto.MessageInfo{
+			Data: &gmproto.MessageInfo_MessageContent{
+				MessageContent: &gmproto.MessageContent{Content: text},
+			},
+		}
+	}
+	return parts
+}
+
+func sendReq(convID string, texts ...string) *gmproto.SendMessageRequest {
+	return &gmproto.SendMessageRequest{
+		ConversationID: convID,
+		MessagePayload: &gmproto.MessagePayload{
+			ConversationID: convID,
+			MessageInfo:    textPayload(texts...),
+		},
+	}
+}
+
+func echo(convID string, status gmproto.MessageStatusType, texts ...string) *gmproto.Message {
+	return &gmproto.Message{
+		ConversationID: convID,
+		MessageStatus:  &gmproto.MessageStatus{Status: status},
+		MessageInfo:    textPayload(texts...),
+	}
+}
+
+func TestMatchPendingSend(t *testing.T) {
+	gc := &GMClient{}
+	gc.addPendingSend(networkid.TransactionID("tmp_1"), sendReq("6", "hello"))
+
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_OUTGOING_SENDING, "hello")); got != "tmp_1" {
+		t.Fatalf("expected tmp_1, got %q", got)
+	}
+	// The match is consumed, so later status events for the same message don't re-match.
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_OUTGOING_COMPLETE, "hello")); got != "" {
+		t.Fatalf("expected no second match, got %q", got)
+	}
+}
+
+func TestMatchPendingSendIgnoresIncoming(t *testing.T) {
+	gc := &GMClient{}
+	gc.addPendingSend(networkid.TransactionID("tmp_1"), sendReq("6", "hello"))
+
+	// An incoming message with identical text must never consume a pending send.
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_INCOMING_COMPLETE, "hello")); got != "" {
+		t.Fatalf("expected no match for incoming message, got %q", got)
+	}
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_OUTGOING_SENDING, "hello")); got != "tmp_1" {
+		t.Fatalf("expected pending send to still be available, got %q", got)
+	}
+}
+
+func TestMatchPendingSendWrongConversation(t *testing.T) {
+	gc := &GMClient{}
+	gc.addPendingSend(networkid.TransactionID("tmp_1"), sendReq("6", "hello"))
+
+	if got := gc.matchPendingSend(echo("7", gmproto.MessageStatusType_OUTGOING_SENDING, "hello")); got != "" {
+		t.Fatalf("expected no cross-conversation match, got %q", got)
+	}
+}
+
+func TestMatchPendingSendDuplicateTextIsFIFO(t *testing.T) {
+	gc := &GMClient{}
+	gc.addPendingSend(networkid.TransactionID("tmp_1"), sendReq("6", "ok"))
+	gc.addPendingSend(networkid.TransactionID("tmp_2"), sendReq("6", "ok"))
+
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_OUTGOING_SENDING, "ok")); got != "tmp_1" {
+		t.Fatalf("expected tmp_1 first, got %q", got)
+	}
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_OUTGOING_SENDING, "ok")); got != "tmp_2" {
+		t.Fatalf("expected tmp_2 second, got %q", got)
+	}
+}
+
+func TestRemovePendingSend(t *testing.T) {
+	gc := &GMClient{}
+	gc.addPendingSend(networkid.TransactionID("tmp_1"), sendReq("6", "hello"))
+	gc.removePendingSend(networkid.TransactionID("tmp_1"))
+
+	if got := gc.matchPendingSend(echo("6", gmproto.MessageStatusType_OUTGOING_SENDING, "hello")); got != "" {
+		t.Fatalf("expected no match after removal, got %q", got)
+	}
+}
+
+// The hash used for matching must be identical to the one getTextPart stores in message metadata,
+// otherwise sends and echoes would never line up.
+func TestHashMatchesGetTextPart(t *testing.T) {
+	msg := echo("6", gmproto.MessageStatusType_OUTGOING_SENDING, "hello", "world")
+	_, textHash := getTextPart(msg)
+	if textHash == "" {
+		t.Fatal("expected getTextPart to produce a hash")
+	}
+	if got := hashMessageText(msg.GetSubject(), msg.GetMessageInfo()); got != textHash {
+		t.Fatalf("hash mismatch: getTextPart=%q hashMessageText=%q", textHash, got)
+	}
+}


### PR DESCRIPTION
Google Messages normally echoes the tmpID from SendMessageRequest back in the message events for that message, which is how outgoing messages are matched to the Matrix event that caused them. Since 2026-08-04 the server has stopped filling the field on new messages, so every message sent from Matrix comes back looking like a new message from the phone and gets duplicated into the Matrix room.

Remember recently sent messages and match tmpID-less echoes against them by conversation and text hash, using the same hash getTextPart already computes for message metadata. Matching is limited to outgoing statuses and non-old messages, and each entry is consumed on first match, so incoming messages and later status updates can't take a pending send.

The normal tmpID path is unchanged, so this stops applying by itself if the server starts sending tmpIDs again.

### Checklist

* [ ] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
