### PR TITLE
connector: resync chats with pending sends when push throttling ends

### DIFF
--- a/pkg/connector/chatsync.go
+++ b/pkg/connector/chatsync.go
@@ -90,6 +90,103 @@ func (gc *GMClient) resyncAfterDataResume(ctx context.Context, lastDataReceived 
 	gc.SyncConversations(ctx, lastDataReceived, true)
 }
 
+// pendingSend records where a message that hasn't been echoed back yet was sent, so the chat
+// can be resynced if the phone never sends the remote echo.
+type pendingSend struct {
+	convID string
+	sentAt time.Time
+}
+
+const (
+	pendingSendTrackMaxAge      = 1 * time.Hour
+	pendingSendResyncDelay      = 15 * time.Second
+	pendingSendResyncExtraChats = 10
+)
+
+func (gc *GMClient) trackPendingSend(txnID networkid.TransactionID, convID string) {
+	if txnID == "" || convID == "" {
+		return
+	}
+	gc.pendingSendsLock.Lock()
+	defer gc.pendingSendsLock.Unlock()
+	gc.pendingSends[txnID] = pendingSend{convID: convID, sentAt: time.Now()}
+}
+
+func (gc *GMClient) untrackPendingSend(txnID networkid.TransactionID) {
+	if txnID == "" {
+		return
+	}
+	gc.pendingSendsLock.Lock()
+	defer gc.pendingSendsLock.Unlock()
+	delete(gc.pendingSends, txnID)
+}
+
+func (gc *GMClient) pendingSendChats() map[string]struct{} {
+	gc.pendingSendsLock.Lock()
+	defer gc.pendingSendsLock.Unlock()
+	convIDs := make(map[string]struct{})
+	for txnID, send := range gc.pendingSends {
+		if time.Since(send.sentAt) > pendingSendTrackMaxAge {
+			delete(gc.pendingSends, txnID)
+			continue
+		}
+		convIDs[send.convID] = struct{}{}
+	}
+	return convIDs
+}
+
+// resyncChatsWithPendingSends is triggered when the phone reports that it has stopped
+// throttling pushes. Grab any pending sends without echos and sync those conversations.
+func (gc *GMClient) resyncChatsWithPendingSends(ctx context.Context) {
+	select {
+	case <-time.After(pendingSendResyncDelay):
+	case <-ctx.Done():
+		return
+	}
+	convIDs := gc.pendingSendChats()
+	if len(convIDs) == 0 {
+		return
+	}
+	cli := gc.Client
+	if cli == nil {
+		return
+	}
+	log := gc.UserLogin.Log.With().Str("action", "resync chats with pending sends").Logger()
+	ctx = log.WithContext(ctx)
+	count := len(convIDs) + pendingSendResyncExtraChats
+	if count < gc.Main.Config.InitialChatSyncCount {
+		count = gc.Main.Config.InitialChatSyncCount
+	}
+	log.Debug().
+		Int("pending_chat_count", len(convIDs)).
+		Int("list_count", count).
+		Msg("Push throttling ended with sends still waiting for an echo, resyncing affected chats")
+	resp, err := cli.ListConversations(ctx, count, gmproto.ListConversationsRequest_INBOX)
+	if err != nil {
+		log.Err(err).Msg("Failed to list conversations to resync pending sends")
+		return
+	}
+	var resynced int
+	for _, conv := range resp.GetConversations() {
+		if _, ok := convIDs[conv.GetConversationID()]; !ok {
+			continue
+		}
+		delete(convIDs, conv.GetConversationID())
+		gc.chatInfoCache.Set(conv.GetConversationID(), conv)
+		gc.Main.br.QueueRemoteEvent(gc.UserLogin, &GMChatResync{
+			g:             gc,
+			Conv:          conv,
+			AllowBackfill: true,
+			OnlyBackfill:  true,
+		})
+		resynced++
+	}
+	log.Debug().
+		Int("resynced", resynced).
+		Int("not_in_conversation_list", len(convIDs)).
+		Msg("Queued backfills for chats with pending sends")
+}
+
 const (
 	stallRecoveryInitialDelay = 2 * time.Minute
 	stallRecoveryRecheckDelay = 5 * time.Minute

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -77,6 +77,9 @@ type GMClient struct {
 	conversationMeta     map[string]*conversationMeta
 	conversationMetaLock sync.Mutex
 
+	pendingSends     map[networkid.TransactionID]pendingSend
+	pendingSendsLock sync.Mutex
+
 	contactsFetchLock  sync.Mutex
 	contactsFetchedAt  time.Time
 	cachedContacts     []*gmproto.Contact
@@ -103,6 +106,7 @@ func (gc *GMConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLo
 		conversationMeta:    make(map[string]*conversationMeta),
 		chatInfoCache:       exsync.NewMap[string, *gmproto.Conversation](),
 		chatInfoFetchFailed: exsync.NewMap[string, time.Time](),
+		pendingSends:        make(map[networkid.TransactionID]pendingSend),
 	}
 	gcli.NewClient()
 	login.Client = gcli

--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -335,6 +335,7 @@ func (gc *GMClient) handleUserAlert(ctx context.Context, v *gmproto.UserAlertEve
 		return
 	case gmproto.AlertType_PUSH_THROTTLE_ENDED:
 		gc.pushThrottled.Store(false)
+		go gc.resyncChatsWithPendingSends(context.WithoutCancel(ctx))
 		return
 	default:
 		return

--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -88,6 +88,7 @@ func (gc *GMClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Matri
 			// The server accepted the message, so the phone may still send it whenever
 			// it comes back online. Keep the pending entry so the remote echo can
 			// resolve the original event (and correct the failure status) if that happens.
+			gc.trackPendingSend(txnID, req.GetConversationID())
 			return nil, bridgev2.WrapErrorInStatus(err).
 				WithMessage(PhoneNotRespondingMessage).
 				WithErrorReason(event.MessageStatusTooOld).
@@ -104,6 +105,7 @@ func (gc *GMClient) HandleMatrixMessage(ctx context.Context, msg *bridgev2.Matri
 		return nil, bridgev2.WrapErrorInStatus((*responseStatusError)(resp)).
 			WithIsCertain(!isTransientSendFailure(resp.Status)).WithSendNotice(true).WithErrorAsMessage()
 	}
+	gc.trackPendingSend(txnID, req.GetConversationID())
 	return &bridgev2.MatrixMessageResponse{Pending: true}, nil
 }
 
@@ -124,6 +126,9 @@ func isTransientSendFailure(status gmproto.SendMessageResponse_Status) bool {
 }
 
 func (gc *GMClient) handleRemoteEcho(rawEvt bridgev2.RemoteMessage, dbMessage *database.Message) (saveMessage bool, statusErr error) {
+	if txnEvt, ok := rawEvt.(bridgev2.RemoteMessageWithTransactionID); ok {
+		gc.untrackPendingSend(txnEvt.GetTransactionID())
+	}
 	var meta *MessageMetadata
 	switch evt := rawEvt.(type) {
 	case *MessageEvent:


### PR DESCRIPTION
The phone stops delivering message events while it's throttling pushes, and once throttling ends it does not replay the ones it suppressed. Messages sent during a throttle window can therefore sit pending indefinitely with a `phone has not confirmed message delivery` error on the Matrix event, even though they were sent, delivered and read.

A forward backfill is what reconnects those messages to their Matrix event, but chat resyncs arriving on their own don't reliably trigger one:

- `syncConversation` sets `AllowBackfill` only when the conversation's latest message is more than 5 minutes old, so a chat you just sent to gets the delayed path instead
- the delayed backfill waits 15s and is cancelled by the next conversation update for that chat — and a draining backlog produces a steady stream of those

So recovery today is incidental. This makes it deliberate: track which conversation each unechoed send went to, and when the phone reports `PUSH_THROTTLE_ENDED`, queue a backfill-only resync for exactly those chats.

Notes on the shape:

- **One `ListConversations` call, not one fetch per chat.** A blast can span 100+ conversations and the phone has just told us it's overloaded. The request size is the pending chat count plus a little headroom, floored at `initial_chat_sync_count`.
- **15s delay before listing**, so the phone has a moment to work through the backlog and the list reflects current state.
- **Entries expire after an hour.** Pending messages only live in memory, so there is nothing left to recover past that, and it bounds the map for sends that never resolve.
- `OnlyBackfill: true`, so this can't create portals or churn chat info — it purely asks for a backfill.

### Measurements

Same heavy sender as #78, 7 days: 27 throttle windows, 1092 timed-out sends, of which only 314 (29%) ever had their pending entry resolved at all. Of the resolutions that did happen, 58% came through a backfill (against a 13% baseline for healthy echoes), which is what suggested making that path deterministic rather than leaving it to chance.

### Relationship to #78

Complementary, and they don't conflict — but this one is only fully effective with #78, which stops `FetchMessages` discarding messages older than the backfill anchor. Without it, this reliably triggers the backfill but the anchor cutoff still drops any echo that flushed out of order, so recovery is limited to chats where the pending message is the newest one (broadcast-style sends, which is a real chunk of the observed damage but not all of it).

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>

🤖 Generated with [Claude Code](https://claude.com/claude-code)