### PR TITLE
backfill: don't include incoming messages in backfill batches

### DIFF
--- a/pkg/connector/backfill.go
+++ b/pkg/connector/backfill.go
@@ -54,6 +54,10 @@ func parsePaginationCursor(cursor networkid.PaginationCursor) (*gmproto.Cursor, 
 	}, nil
 }
 
+type backfillBundleData struct {
+	LatestMessageID string
+}
+
 // Allow messages that pre-date the anchor message if they are: sent by us and within this timeframe,
 // this allows messages that send late on the phone side to be updated and have the correct send status.
 const pendingSendMaxAge = 24 * time.Hour
@@ -93,6 +97,10 @@ func (gc *GMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMess
 			}
 		}
 	}
+	var latestMessageID string
+	if bundle, ok := params.BundledData.(*backfillBundleData); ok && params.Forward {
+		latestMessageID = bundle.LatestMessageID
+	}
 	resp, err := gc.Client.FetchMessages(ctx, convID, int64(params.Count), cursor)
 	if err != nil {
 		return nil, err
@@ -113,7 +121,8 @@ func (gc *GMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMess
 		MarkRead:         false,
 		ApproxTotalCount: int(resp.TotalMessages),
 	}
-	for _, msg := range resp.Messages {
+	var lastRawMsg *gmproto.Message
+	for i, msg := range resp.Messages {
 		msgTS := time.UnixMicro(msg.Timestamp)
 		log := zerolog.Ctx(ctx).With().Str("message_id", msg.MessageID).Time("message_ts", msgTS).Logger()
 		if !params.Forward && cursor != nil && msgTS.UnixMilli() >= cursor.LastItemTimestamp {
@@ -127,6 +136,9 @@ func (gc *GMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMess
 				Time("anchor_ts", anchorTS).
 				Str("anchor_message_id", anchorMsgID).
 				Msg("Ignoring message older than anchor message")
+			continue
+		} else if latestMessageID != "" && latestMessageID == msg.MessageID && i == len(resp.Messages)-1 {
+			log.Debug().Msg("Ignoring latest message in backfill, it will be bridged as a live event")
 			continue
 		}
 		ctx := log.WithContext(ctx)
@@ -149,6 +161,7 @@ func (gc *GMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMess
 			Reactions:   (&ReactionSyncEvent{Message: msg, g: gc}).GetReactions().ToBackfill(),
 		}
 		fetchResp.Messages = append(fetchResp.Messages, backfillMsg)
+		lastRawMsg = msg
 	}
 	if len(fetchResp.Messages) == 0 {
 		return fetchResp, nil
@@ -160,7 +173,6 @@ func (gc *GMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMess
 		meta := gc.conversationMeta[convID]
 		if meta != nil {
 			lastWrappedMsg := fetchResp.Messages[len(fetchResp.Messages)-1]
-			lastRawMsg := resp.Messages[len(resp.Messages)-1]
 			fetchResp.MarkRead = !meta.unread || !meta.readUpToTS.Before(lastWrappedMsg.Timestamp) || meta.readUpTo == lastRawMsg.MessageID
 		}
 		gc.conversationMetaLock.Unlock()

--- a/pkg/connector/chatsync.go
+++ b/pkg/connector/chatsync.go
@@ -364,6 +364,7 @@ type GMChatResync struct {
 var (
 	_ bridgev2.RemoteChatResyncWithInfo       = (*GMChatResync)(nil)
 	_ bridgev2.RemoteChatResyncBackfill       = (*GMChatResync)(nil)
+	_ bridgev2.RemoteChatResyncBackfillBundle = (*GMChatResync)(nil)
 	_ bridgev2.RemoteChatDelete               = (*GMChatResync)(nil)
 	_ bridgev2.RemoteEventThatMayCreatePortal = (*GMChatResync)(nil)
 )
@@ -394,6 +395,13 @@ func (evt *GMChatResync) ShouldCreatePortal() bool {
 		return false
 	}
 	return true
+}
+
+func (evt *GMChatResync) GetBundledBackfillData() any {
+	if evt.AllowBackfill {
+		return nil
+	}
+	return &backfillBundleData{LatestMessageID: evt.Conv.LatestMessageID}
 }
 
 func (evt *GMChatResync) GetPortalKey() networkid.PortalKey {

--- a/pkg/connector/handlegmessages.go
+++ b/pkg/connector/handlegmessages.go
@@ -723,6 +723,7 @@ var (
 	_ bridgev2.RemoteEventThatMayCreatePortal = (*MessageEvent)(nil)
 	_ bridgev2.RemoteEventWithTimestamp       = (*MessageEvent)(nil)
 	_ bridgev2.RemoteEventWithStreamOrder     = (*MessageEvent)(nil)
+	_ bridgev2.RemoteChatResyncBackfillBundle = (*MessageEvent)(nil)
 )
 
 func (m *MessageEvent) GetType() bridgev2.RemoteEventType {
@@ -752,6 +753,22 @@ func (m *MessageEvent) ShouldCreatePortal() bool {
 	default:
 		return false
 	}
+}
+
+// Flag incoming messages younger than this as latest such that we skip them during the backfill
+// stage and they come through as a regular incoming message.
+const backfillLatestMaxAge = 1 * time.Hour
+
+func (m *MessageEvent) GetBundledBackfillData() any {
+	if time.Since(m.GetTimestamp()) > backfillLatestMaxAge {
+		return nil
+	}
+	return &backfillBundleData{LatestMessageID: m.MessageID}
+}
+
+// Needed for GetBundledBackfillData to run
+func (m *MessageEvent) CheckNeedsBackfill(ctx context.Context, latestMessage *database.Message) (bool, error) {
+	return false, nil
 }
 
 func (m *MessageEvent) AddLogContext(c zerolog.Context) zerolog.Context {


### PR DESCRIPTION
When the message comes through in the backfill payload it is bridged but notifications are suppressed, and when it comes again via the incoming path it is deduped.
