### PR TITLE
errors: improve message when the phone rejects a send

### DIFF
--- a/pkg/connector/errors.go
+++ b/pkg/connector/errors.go
@@ -33,7 +33,7 @@ func (rse *responseStatusError) Error() string {
 		if rse.GoogleAccountSwitch != nil && strings.ContainsRune(rse.GoogleAccountSwitch.GetAccount(), '@') {
 			return "Switch back to QR pairing or log in with Google account to send messages"
 		}
-		return "Google Messages on your phone rejected the message — check that you can send from the Messages app, or try re-pairing"
+		return "Google Messages on your phone rejected the message. Check that you can send from the Messages app, or try re-pairing"
 	case gmproto.SendMessageResponse_FAILURE_2:
 		return "Unknown permanent error"
 	case gmproto.SendMessageResponse_FAILURE_3:

--- a/pkg/connector/errors.go
+++ b/pkg/connector/errors.go
@@ -33,6 +33,7 @@ func (rse *responseStatusError) Error() string {
 		if rse.GoogleAccountSwitch != nil && strings.ContainsRune(rse.GoogleAccountSwitch.GetAccount(), '@') {
 			return "Switch back to QR pairing or log in with Google account to send messages"
 		}
+		return "Google Messages on your phone rejected the message — check that you can send from the Messages app, or try re-pairing"
 	case gmproto.SendMessageResponse_FAILURE_2:
 		return "Unknown permanent error"
 	case gmproto.SendMessageResponse_FAILURE_3:


### PR DESCRIPTION
When the paired phone answered a send with status 0 and no Google account switch, the bridge surfaced the developer string "Unrecognized response status 0" to the user, this is at least a bit better!
