### PR TITLE
stableid: re-ID SMS/MMS group portals onto upgraded RCS groups

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -77,11 +77,12 @@ type GMClient struct {
 	pendingSends     map[networkid.TransactionID]pendingSend
 	pendingSendsLock sync.Mutex
 
-	portalIDByConv       *exsync.Map[string, networkid.PortalID]
-	portalIDsLoaded      atomic.Bool
-	stableIDRepointLocks *exsync.Map[string, *sync.Mutex]
-	messageQueue         chan *libgm.WrappedMessage
-	stopMessageQueue     atomic.Pointer[context.CancelFunc]
+	portalIDByConv                   *exsync.Map[string, networkid.PortalID]
+	legacyPortalKeyByParticipantHash *exsync.Map[string, networkid.PortalKey]
+	portalIDsLoaded                  atomic.Bool
+	stableIDRepointLocks             *exsync.Map[string, *sync.Mutex]
+	messageQueue                     chan *libgm.WrappedMessage
+	stopMessageQueue                 atomic.Pointer[context.CancelFunc]
 
 	contactsFetchLock  sync.Mutex
 	contactsFetchedAt  time.Time
@@ -111,9 +112,10 @@ func (gc *GMConnector) LoadUserLogin(ctx context.Context, login *bridgev2.UserLo
 		chatInfoFetchFailed: exsync.NewMap[string, time.Time](),
 		pendingSends:        make(map[networkid.TransactionID]pendingSend),
 
-		portalIDByConv:       exsync.NewMap[string, networkid.PortalID](),
-		stableIDRepointLocks: exsync.NewMap[string, *sync.Mutex](),
-		messageQueue:         make(chan *libgm.WrappedMessage, 128),
+		portalIDByConv:                   exsync.NewMap[string, networkid.PortalID](),
+		legacyPortalKeyByParticipantHash: exsync.NewMap[string, networkid.PortalKey](),
+		stableIDRepointLocks:             exsync.NewMap[string, *sync.Mutex](),
+		messageQueue:                     make(chan *libgm.WrappedMessage, 128),
 	}
 	gcli.NewClient()
 	login.Client = gcli

--- a/pkg/connector/stableid.go
+++ b/pkg/connector/stableid.go
@@ -171,6 +171,9 @@ func (gc *GMClient) loadPortalIDs(ctx context.Context) {
 				gc.rememberPortalID(convID, portal.ID)
 				legacy++
 			}
+			if meta.ParticipantHash != "" {
+				gc.legacyPortalKeyByParticipantHash.Set(meta.ParticipantHash, portal.PortalKey)
+			}
 			continue
 		}
 		gc.rememberPortalID(meta.ConversationID, portal.ID)
@@ -263,7 +266,8 @@ func (gc *GMClient) PortalKeyForConversation(ctx context.Context, conversationID
 // fresh portal at the stable key while the legacy one is still around.
 func (gc *GMClient) repointPortalIfNeeded(ctx context.Context, conv *gmproto.Conversation) {
 	convID := conv.GetConversationID()
-	stableID := gc.computeStableIdentity(conv).StableID
+	ident := gc.computeStableIdentity(conv)
+	stableID := ident.StableID
 	if convID == "" || stableID == "" {
 		return
 	}
@@ -305,6 +309,9 @@ func (gc *GMClient) repointPortalIfNeeded(ctx context.Context, conv *gmproto.Con
 			log.Info().Stringer("reid_result", result).Msg("Re-ID'd legacy portal onto stable key")
 		}
 	}
+	if strings.HasPrefix(stableID, stableIDPrefixRCSGroup) {
+		gc.reIDRCSGroupPredecessor(ctx, ident, stableKey)
+	}
 	gc.rememberPortalID(convID, stableKey.ID)
 
 	// Update the send-routing handle if Google re-keyed the conversation.
@@ -323,6 +330,68 @@ func (gc *GMClient) repointPortalIfNeeded(ctx context.Context, conv *gmproto.Con
 	if err = portal.Save(ctx); err != nil {
 		log.Err(err).Msg("Failed to save portal after re-pointing conversation ID")
 	}
+}
+
+// reIDRCSGroupPredecessor merges the SMS/MMS portal a group was upgraded from onto its new RCS
+// group key. Google issues an upgraded RCS group as a fresh conversation with a new identity, so
+// without this the existing room and history would be abandoned and a new portal backfilled.
+//
+// The predecessor is matched by participant hash, guarded on participant count, and only when the
+// RCS portal doesn't exist yet, so a still-live SMS group is never merged into a coincidental RCS
+// group with the same members.
+func (gc *GMClient) reIDRCSGroupPredecessor(ctx context.Context, ident stableIdentity, rcsKey networkid.PortalKey) {
+	if ident.ParticipantHash == "" {
+		return
+	}
+	log := zerolog.Ctx(ctx)
+	rcsPortal, err := gc.Main.br.GetExistingPortalByKey(ctx, rcsKey)
+	if err != nil {
+		log.Err(err).Msg("Failed to look up RCS group portal before merging predecessor")
+		return
+	} else if rcsPortal != nil {
+		return
+	}
+	predecessorKey, ok := gc.findParticipantHashPredecessor(ctx, ident, rcsKey)
+	if !ok {
+		return
+	}
+	log.Info().
+		Stringer("predecessor_portal_key", predecessorKey).
+		Stringer("rcs_portal_key", rcsKey).
+		Msg("Merging SMS/MMS predecessor portal into upgraded RCS group")
+	result, _, err := gc.Main.br.ReIDPortal(ctx, predecessorKey, rcsKey)
+	if err != nil {
+		log.Err(err).Msg("Failed to re-ID SMS/MMS predecessor onto RCS group key")
+		return
+	}
+	log.Info().Stringer("reid_result", result).Msg("Re-ID'd SMS/MMS predecessor onto RCS group key")
+}
+
+func (gc *GMClient) findParticipantHashPredecessor(ctx context.Context, ident stableIdentity, rcsKey networkid.PortalKey) (networkid.PortalKey, bool) {
+	candidates := []networkid.PortalKey{gc.MakePortalKey(stableIDPrefixParticipants + ident.ParticipantHash)}
+	if legacyKey, ok := gc.legacyPortalKeyByParticipantHash.Get(ident.ParticipantHash); ok {
+		candidates = append(candidates, legacyKey)
+	}
+	log := zerolog.Ctx(ctx)
+	for _, key := range candidates {
+		if key == rcsKey {
+			continue
+		}
+		portal, err := gc.Main.br.GetExistingPortalByKey(ctx, key)
+		if err != nil {
+			log.Err(err).Stringer("candidate_portal_key", key).Msg("Failed to look up predecessor portal candidate")
+			continue
+		}
+		if portal == nil {
+			continue
+		}
+		meta, ok := portal.Metadata.(*PortalMetadata)
+		if !ok || meta.ParticipantCount != ident.ParticipantCount {
+			continue
+		}
+		return key, true
+	}
+	return networkid.PortalKey{}, false
 }
 
 // isLegacyPortalID reports whether a portal is still keyed on the mutable conversation ID rather


### PR DESCRIPTION
When Google upgrades a group from SMS/MMS to RCS it issues a fresh conversation with a new identity, so the bridge created a second portal and backfilled the history into it instead of reusing the existing room.

Match the predecessor portal by participant hash and re-ID it onto the new RCS group key while that portal doesn't exist yet, carrying the existing room and history across.
