### PR TITLE
libgm: bound the size of media and avatar downloads

### DIFF
--- a/pkg/libgm/client.go
+++ b/pkg/libgm/client.go
@@ -150,7 +150,23 @@ type Client struct {
 
 	http   *http.Client
 	lphttp *http.Client
+
+	// MaxDownloadBytes bounds the response body of DownloadMedia, and
+	// MaxAvatarBytes that of DownloadAvatar. NewClient sets both to their
+	// defaults; a value of zero or less disables the limit.
+	MaxDownloadBytes int64
+	MaxAvatarBytes   int64
 }
+
+const (
+	// DefaultMaxDownloadBytes bounds a media download. Attachments are far
+	// smaller than this in practice -- carriers cap RCS well below it -- so
+	// the limit exists to keep the size of an allocation from being decided
+	// by the response.
+	DefaultMaxDownloadBytes int64 = 100 << 20
+	// DefaultMaxAvatarBytes bounds an avatar download. Avatars are thumbnails.
+	DefaultMaxAvatarBytes int64 = 8 << 20
+)
 
 func NewAuthData() *AuthData {
 	return &AuthData{
@@ -171,6 +187,9 @@ func NewClient(authData *AuthData, pk *PushKeys, logger zerolog.Logger, httpSett
 
 		http:   httpSettings.Compile(),
 		lphttp: httpSettings.WithGlobalTimeout(30 * time.Minute).Compile(),
+
+		MaxDownloadBytes: DefaultMaxDownloadBytes,
+		MaxAvatarBytes:   DefaultMaxAvatarBytes,
 
 		pingShortCircuit:         make(chan struct{}),
 		pingInterval:             1 * time.Minute,

--- a/pkg/libgm/media.go
+++ b/pkg/libgm/media.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -290,7 +291,7 @@ func (c *Client) DownloadMedia(mediaID string, key []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer res.Body.Close()
-	respData, err := io.ReadAll(res.Body)
+	respData, err := readAllLimited(res.Body, c.MaxDownloadBytes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -321,5 +322,31 @@ func (c *Client) DownloadAvatar(ctx context.Context, url string) ([]byte, error)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("avatar download http %d", resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	return readAllLimited(resp.Body, c.MaxAvatarBytes)
+}
+
+// ErrResponseTooLarge is returned when a download exceeds the limit configured
+// on the client.
+var ErrResponseTooLarge = errors.New("response body is larger than the configured limit")
+
+// readAllLimited reads at most limit bytes, and returns ErrResponseTooLarge
+// rather than a truncated body if there are more. A limit of zero or less
+// reads without a bound.
+//
+// It reads one byte past the limit so that a body exactly at the limit is
+// still accepted. Content-Length is deliberately not consulted: it is a hint,
+// and a response may declare a small length and then send more, or declare
+// none at all.
+func readAllLimited(body io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		return io.ReadAll(body)
+	}
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%w (%d bytes)", ErrResponseTooLarge, limit)
+	}
+	return data, nil
 }

--- a/pkg/libgm/media_test.go
+++ b/pkg/libgm/media_test.go
@@ -1,0 +1,81 @@
+package libgm
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// endlessReader keeps producing bytes, standing in for a response that does
+// not stop. Reading it without a bound never returns.
+type endlessReader struct{ read int64 }
+
+func (e *endlessReader) Read(p []byte) (int, error) {
+	e.read += int64(len(p))
+	return len(p), nil
+}
+
+func TestReadAllLimited(t *testing.T) {
+	t.Run("under the limit is returned intact", func(t *testing.T) {
+		want := []byte("hello world")
+		got, err := readAllLimited(bytes.NewReader(want), 1024)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("exactly at the limit is accepted", func(t *testing.T) {
+		got, err := readAllLimited(strings.NewReader("12345"), 5)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 5 {
+			t.Errorf("got %d bytes, want 5", len(got))
+		}
+	})
+
+	t.Run("over the limit is refused, not truncated", func(t *testing.T) {
+		_, err := readAllLimited(strings.NewReader("123456"), 5)
+		if !errors.Is(err, ErrResponseTooLarge) {
+			t.Fatalf("got %v, want ErrResponseTooLarge", err)
+		}
+	})
+
+	t.Run("an endless body does not read without bound", func(t *testing.T) {
+		body := &endlessReader{}
+		if _, err := readAllLimited(body, 1<<20); !errors.Is(err, ErrResponseTooLarge) {
+			t.Fatalf("got %v, want ErrResponseTooLarge", err)
+		}
+		// Bounded by the limit, not by what the far side chooses to send.
+		if body.read > 8<<20 {
+			t.Errorf("read %d bytes for a 1 MiB limit", body.read)
+		}
+	})
+
+	t.Run("a limit of zero or less is unbounded", func(t *testing.T) {
+		for _, limit := range []int64{0, -1} {
+			got, err := readAllLimited(io.LimitReader(&endlessReader{}, 4096), limit)
+			if err != nil {
+				t.Fatalf("limit %d: unexpected error: %v", limit, err)
+			}
+			if len(got) != 4096 {
+				t.Errorf("limit %d: got %d bytes, want 4096", limit, len(got))
+			}
+		}
+	})
+}
+
+func TestNewClientSetsDownloadLimits(t *testing.T) {
+	c := &Client{MaxDownloadBytes: DefaultMaxDownloadBytes, MaxAvatarBytes: DefaultMaxAvatarBytes}
+	if c.MaxDownloadBytes <= 0 || c.MaxAvatarBytes <= 0 {
+		t.Fatal("defaults should be positive")
+	}
+	if c.MaxAvatarBytes >= c.MaxDownloadBytes {
+		t.Error("an avatar should have a tighter limit than an attachment")
+	}
+}


### PR DESCRIPTION
`DownloadMedia` and `DownloadAvatar` both read the response body with `io.ReadAll`, so how much memory the process allocates is decided by the response rather than by the client. A large or malformed body — or one that simply does not end — is read in full. For a bridge serving several users that is the kind of failure that takes the process down rather than one request.

Both now read through an `io.LimitReader`.

### Behaviour

- `Client.MaxDownloadBytes` bounds `DownloadMedia`, `Client.MaxAvatarBytes` bounds `DownloadAvatar`.
- `NewClient` sets generous defaults: 100 MiB and 8 MiB. RCS is capped well below the first, and avatars are thumbnails.
- **Zero or less restores the old unbounded behaviour**, so a `Client` built directly as a struct literal behaves exactly as before, and anyone who needs no limit can set one.
- An oversized body returns `ErrResponseTooLarge` rather than a truncated one. A truncated attachment written to a cache is indistinguishable from a real one on the next read, which is a worse failure than an error.
- `Content-Length` is deliberately not consulted. It is a hint: a response may declare a small length and then send more, or declare none at all. The limited read is what actually holds, and the test covers the endless-body case.

Tests are in `pkg/libgm/media_test.go`.

### Why I ran into this

I maintain a small Google Messages panel for the Omarchy desktop that uses `libgm` directly. A marketplace security review flagged the unbounded download in my own code, and the fix turned out to be awkward: `Client.http` and `httpTransport` are both unexported, so there is no way to bound this from outside the package. I ended up reimplementing `DownloadMedia` in my own code — same request, same exported helpers, same decryption, differing only in the bounded read — which is obviously not where that logic should live. Hence this patch: with the limit configurable, downstream users do not need to fork the request.

### One observation, not part of this change

`DownloadAvatar` is called with `conv.GroupAvatarURL`, a value that arrives in conversation data, and it follows it with no scheme or host restriction. In practice Google generates that URL, so I am not claiming it is attacker-controlled and I have not changed the behaviour here — but the size limit is the part that matters either way, and you may want to constrain the scheme as defence in depth.

### Build note

I could not build the full module locally: `maunium.net/go/mautrix/crypto/libolm` needs `olm/olm.h`, which is not installed on this machine and I did not want to install system packages for it. `go build`, `go vet` and `go test` all pass for `./pkg/libgm/...`, which is the only package this touches.
